### PR TITLE
Update Repo - 002 - Add gitleaks scanning and concurrency to PR workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,12 +12,33 @@ on:
   pull_request: 
     branches: 
       - main
-      - develop
+concurrency:  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}  cancel-in-progress: true
     paths-ignore:
       - '**.md'
       - 'docs/**'
       - '.github/workflows/**'
+
 jobs:
+  # SECRETS SCAN: Detect leaked credentials before merge
+  # ============================================================================
+  secrets-scan:
+    name: "Secrets Scan (gitleaks)"
+    runs-on: ubuntu-latest
+    if: github.repository != 'Chris-Wolfgang/repo-template'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ============================================================================
   # ============================================================================
   # STAGE 1: Linux - .NET Core/5+ Tests with Coverage Gate
   # ============================================================================


### PR DESCRIPTION
## Summary
- Add concurrency groups to cancel superseded workflow runs
- Add gitleaks secrets scanning job

## Test plan
- [ ] Verify gitleaks job runs on next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)