### PR TITLE
Add SECURITY.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -65,7 +65,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-.
+210299580+Chris-Wolfgang@users.noreply.github.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please follow these steps:
+
+1. **Do not** create a public issue on this repository.
+2. In the top navigation of this repository, click the **Security** tab.
+3. In the top right, click the **Report a vulnerability** button.
+4. Fill out the provided form with:
+   - A description of the vulnerability
+   - Steps to reproduce the issue
+   - Potential impact
+   - Suggested fix (if you have one)
+
+## Response Timeline
+
+We will acknowledge your report within 48 hours and provide an estimated timeline for a fix.
+
+## Thank You
+
+Your help is greatly appreciated!
+Responsible disclosure of security vulnerabilities helps protect our entire community.


### PR DESCRIPTION
## Summary
- Add SECURITY.md for responsible vulnerability disclosure via GitHub Security tab

## Test plan
- [ ] Verify SECURITY.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)