### PR TITLE
Add TotalSize() and ExceedsLimit() for AttachmentCollection

### DIFF
--- a/src/Wolfgang.Extensions.Mail/AttachmentCollectionExtensions.cs
+++ b/src/Wolfgang.Extensions.Mail/AttachmentCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Mail;
 
 namespace Wolfgang.Extensions.Mail;
@@ -110,5 +111,57 @@ public static class AttachmentCollectionExtensions
     )
     // ReSharper disable once InvokeAsExtensionMember
         => AddRange(source, (IEnumerable<string>)fileNames);
+
+
+
+    /// <summary>
+    /// Returns the total size in bytes of all attachments in the <see cref="AttachmentCollection"/>
+    /// whose underlying streams support seeking. Non-seekable streams are excluded from the total.
+    /// </summary>
+    /// <param name="source">The <see cref="AttachmentCollection"/> to measure.</param>
+    /// <returns>The total size in bytes of all seekable attachment streams.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+    /// <example>
+    /// <code>
+    /// using var message = new MailMessage();
+    /// message.Attachments.AddRange("report.pdf", "data.csv");
+    /// long totalBytes = message.Attachments.TotalSize();
+    /// </code>
+    /// </example>
+    // ReSharper disable once UnusedMember.Global
+    public static long TotalSize
+    (
+        this AttachmentCollection source
+    )
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        return source
+            .Where(a => a.ContentStream.CanSeek)
+            .Sum(a => a.ContentStream.Length);
+    }
+
+
+
+    /// <summary>
+    /// Returns a value indicating whether the total size of all attachments exceeds
+    /// the specified maximum number of bytes.
+    /// </summary>
+    /// <param name="source">The <see cref="AttachmentCollection"/> to check.</param>
+    /// <param name="maxBytes">The maximum allowed total size in bytes.</param>
+    /// <returns><c>true</c> if the total attachment size exceeds <paramref name="maxBytes"/>; otherwise, <c>false</c>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public static bool ExceedsLimit
+    (
+        this AttachmentCollection source,
+        long maxBytes
+    )
+    {
+        return source.TotalSize() > maxBytes;
+    }
 
 }

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/AttachmentCollectionExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/AttachmentCollectionExtensionsTests.cs
@@ -256,6 +256,67 @@ public class AttachmentCollectionExtensionsTests
 
 
 
+    // ---------- TotalSize ----------
+
+    [Fact]
+    public void TotalSize_when_source_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => AttachmentCollectionExtensions.TotalSize(null!)
+        );
+        Assert.Equal("source", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void TotalSize_when_no_attachments_returns_zero()
+    {
+        using var msg = new MailMessage();
+        Assert.Equal(0, msg.Attachments.TotalSize());
+    }
+
+
+
+    [Fact]
+    public void TotalSize_when_attachments_exist_returns_sum_of_stream_lengths()
+    {
+        using var msg = new MailMessage();
+        msg.Attachments.Add(new Attachment(new MemoryStream(new byte[100]), "a.bin"));
+        msg.Attachments.Add(new Attachment(new MemoryStream(new byte[200]), "b.bin"));
+
+        Assert.Equal(300, msg.Attachments.TotalSize());
+    }
+
+
+
+    // ---------- ExceedsLimit ----------
+
+    [Fact]
+    public void ExceedsLimit_when_total_exceeds_max_returns_true()
+    {
+        using var msg = new MailMessage();
+        msg.Attachments.Add(new Attachment(new MemoryStream(new byte[1024]), "large.bin"));
+
+        Assert.True(msg.Attachments.ExceedsLimit(512));
+    }
+
+
+
+    [Fact]
+    public void ExceedsLimit_when_total_within_max_returns_false()
+    {
+        using var msg = new MailMessage();
+        msg.Attachments.Add(new Attachment(new MemoryStream(new byte[100]), "small.bin"));
+
+        Assert.False(msg.Attachments.ExceedsLimit(512));
+    }
+
+
+
+    // ---------- Helpers ----------
+
     private static string CreateTempFile(string? prefix = null, string? extension = null)
     {
         var file = Path.Combine(


### PR DESCRIPTION
## Summary
- `TotalSize()` — returns sum of all seekable attachment stream lengths in bytes
- `ExceedsLimit(long maxBytes)` — convenience check against a size threshold

Closes #26

## Test plan
- [x] 82/82 tests pass on net10.0
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)