### PR TITLE
Add ToFormattedString() for MailAddressCollection

### DIFF
--- a/src/Wolfgang.Extensions.Mail/MailAddressCollectionExtensions.cs
+++ b/src/Wolfgang.Extensions.Mail/MailAddressCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Mail;
+using System.Text;
 
 namespace Wolfgang.Extensions.Mail;
 
@@ -113,5 +115,70 @@ public static class MailAddressCollectionExtensions
     )
     // ReSharper disable once InvokeAsExtensionMember
         => AddRange(source, (IEnumerable<MailAddress>)addresses);
+
+
+
+    /// <summary>
+    /// Returns a formatted string representation of all addresses in the
+    /// <see cref="MailAddressCollection"/>, using RFC 5322 display name quoting.
+    /// </summary>
+    /// <param name="source">The <see cref="MailAddressCollection"/> to format.</param>
+    /// <param name="separator">The separator between addresses. Defaults to <c>"; "</c>.</param>
+    /// <returns>A formatted string of all addresses.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+    /// <example>
+    /// <code>
+    /// using var message = new MailMessage();
+    /// message.To.Add(new MailAddress("alice@example.com", "Alice Smith"));
+    /// message.To.Add(new MailAddress("bob@example.com"));
+    /// string formatted = message.To.ToFormattedString();
+    /// // "Alice Smith" &lt;alice@example.com&gt;; bob@example.com
+    /// </code>
+    /// </example>
+    // ReSharper disable once UnusedMember.Global
+    public static string ToFormattedString
+    (
+        this MailAddressCollection source,
+        string separator = "; "
+    )
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        return string.Join
+        (
+            separator,
+            source.Select(FormatMailAddress)
+        );
+    }
+
+
+
+    /// <summary>
+    /// Returns a formatted RFC 5322 string representation of a single <see cref="MailAddress"/>.
+    /// </summary>
+    /// <param name="address">The <see cref="MailAddress"/> to format.</param>
+    /// <returns>A formatted string such as <c>"Display Name" &lt;email@example.com&gt;</c>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="address"/> is null.</exception>
+    // ReSharper disable once MemberCanBePrivate.Global
+    public static string FormatMailAddress
+    (
+        this MailAddress address
+    )
+    {
+        if (address == null)
+        {
+            throw new ArgumentNullException(nameof(address));
+        }
+
+        if (string.IsNullOrEmpty(address.DisplayName))
+        {
+            return address.Address;
+        }
+
+        return $"\"{address.DisplayName}\" <{address.Address}>";
+    }
 
 }

--- a/src/Wolfgang.Extensions.Mail/MailAddressCollectionExtensions.cs
+++ b/src/Wolfgang.Extensions.Mail/MailAddressCollectionExtensions.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Mail;
-using System.Text;
 
 namespace Wolfgang.Extensions.Mail;
 
@@ -178,7 +177,10 @@ public static class MailAddressCollectionExtensions
             return address.Address;
         }
 
-        return $"\"{address.DisplayName}\" <{address.Address}>";
+        var escapedName = address.DisplayName
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"");
+        return $"\"{escapedName}\" <{address.Address}>";
     }
 
 }

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/MailAddressCollectionExtensionsTests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/MailAddressCollectionExtensionsTests.cs
@@ -217,4 +217,91 @@ public class MailAddressCollectionExtensionsTests
         MailAddressCollectionExtensions.AddRange(msg.To, Array.Empty<MailAddress>());
         Assert.Empty(msg.To);
     }
+
+
+
+    // ---------- ToFormattedString ----------
+
+    [Fact]
+    public void ToFormattedString_when_source_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => MailAddressCollectionExtensions.ToFormattedString(null!)
+        );
+        Assert.Equal("source", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void ToFormattedString_when_empty_collection_returns_empty_string()
+    {
+        using var msg = new MailMessage();
+        Assert.Equal("", msg.To.ToFormattedString());
+    }
+
+
+
+    [Fact]
+    public void ToFormattedString_when_address_without_display_name_returns_address_only()
+    {
+        using var msg = new MailMessage();
+        msg.To.Add(new MailAddress("bob@example.com"));
+
+        Assert.Equal("bob@example.com", msg.To.ToFormattedString());
+    }
+
+
+
+    [Fact]
+    public void ToFormattedString_when_address_with_display_name_returns_quoted_format()
+    {
+        using var msg = new MailMessage();
+        msg.To.Add(new MailAddress("alice@example.com", "Alice Smith"));
+
+        Assert.Equal("\"Alice Smith\" <alice@example.com>", msg.To.ToFormattedString());
+    }
+
+
+
+    [Fact]
+    public void ToFormattedString_when_multiple_addresses_joins_with_default_separator()
+    {
+        using var msg = new MailMessage();
+        msg.To.Add(new MailAddress("alice@example.com", "Alice"));
+        msg.To.Add(new MailAddress("bob@example.com"));
+
+        var result = msg.To.ToFormattedString();
+
+        Assert.Equal("\"Alice\" <alice@example.com>; bob@example.com", result);
+    }
+
+
+
+    [Fact]
+    public void ToFormattedString_when_custom_separator_uses_separator()
+    {
+        using var msg = new MailMessage();
+        msg.To.Add(new MailAddress("a@example.com"));
+        msg.To.Add(new MailAddress("b@example.com"));
+
+        var result = msg.To.ToFormattedString(", ");
+
+        Assert.Equal("a@example.com, b@example.com", result);
+    }
+
+
+
+    // ---------- FormatMailAddress ----------
+
+    [Fact]
+    public void FormatMailAddress_when_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => MailAddressCollectionExtensions.FormatMailAddress(null!)
+        );
+        Assert.Equal("address", ex.ParamName);
+    }
 }


### PR DESCRIPTION
## Summary
- `ToFormattedString(separator)` — RFC 5322 formatted address list with quoted display names
- `FormatMailAddress()` — single address extension for `"Name" <email>` format

Closes #24

## Test plan
- [x] 7 tests pass on net10.0
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)