### PR TITLE
Add AttachmentFactory (FromBytes, FromBase64, FromStream)

### DIFF
--- a/src/Wolfgang.Extensions.Mail/AttachmentFactory.cs
+++ b/src/Wolfgang.Extensions.Mail/AttachmentFactory.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Mail;
+using System.Net.Mime;
+
+namespace Wolfgang.Extensions.Mail;
+
+
+/// <summary>
+/// Provides factory methods for creating <see cref="Attachment"/> objects from common sources
+/// with automatic content type inference from file extensions.
+/// </summary>
+// ReSharper disable once UnusedType.Global
+public static class AttachmentFactory
+{
+
+    private static readonly Dictionary<string, string> ContentTypeMap = new Dictionary<string, string>
+    (
+        StringComparer.OrdinalIgnoreCase
+    )
+    {
+        { ".pdf", "application/pdf" },
+        { ".zip", "application/zip" },
+        { ".gz", "application/gzip" },
+        { ".json", "application/json" },
+        { ".xml", "application/xml" },
+        { ".doc", "application/msword" },
+        { ".docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document" },
+        { ".xls", "application/vnd.ms-excel" },
+        { ".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" },
+        { ".ppt", "application/vnd.ms-powerpoint" },
+        { ".pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation" },
+        { ".png", "image/png" },
+        { ".jpg", "image/jpeg" },
+        { ".jpeg", "image/jpeg" },
+        { ".gif", "image/gif" },
+        { ".svg", "image/svg+xml" },
+        { ".bmp", "image/bmp" },
+        { ".ico", "image/x-icon" },
+        { ".webp", "image/webp" },
+        { ".txt", "text/plain" },
+        { ".csv", "text/csv" },
+        { ".html", "text/html" },
+        { ".htm", "text/html" },
+        { ".css", "text/css" },
+        { ".js", "text/javascript" },
+        { ".mp3", "audio/mpeg" },
+        { ".wav", "audio/wav" },
+        { ".mp4", "video/mp4" },
+        { ".avi", "video/x-msvideo" },
+        { ".eml", "message/rfc822" },
+    };
+
+
+
+    /// <summary>
+    /// Creates an <see cref="Attachment"/> from a byte array with automatic content type inference.
+    /// </summary>
+    /// <param name="content">The attachment content as a byte array.</param>
+    /// <param name="fileName">The file name for the attachment (used for content type inference and display).</param>
+    /// <param name="contentType">Optional explicit content type. When <c>null</c>, inferred from <paramref name="fileName"/>.</param>
+    /// <returns>A new <see cref="Attachment"/> backed by a <see cref="MemoryStream"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="content"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="fileName"/> is null.</exception>
+    /// <example>
+    /// <code>
+    /// byte[] pdfBytes = File.ReadAllBytes("report.pdf");
+    /// var attachment = AttachmentFactory.FromBytes(pdfBytes, "report.pdf");
+    /// </code>
+    /// </example>
+    // ReSharper disable once UnusedMember.Global
+    public static Attachment FromBytes
+    (
+        byte[] content,
+        string fileName,
+        string? contentType = null
+    )
+    {
+        if (content == null)
+        {
+            throw new ArgumentNullException(nameof(content));
+        }
+
+        if (fileName == null)
+        {
+            throw new ArgumentNullException(nameof(fileName));
+        }
+
+        var stream = new MemoryStream(content, writable: false);
+        var resolvedContentType = ResolveContentType(fileName, contentType);
+
+        return new Attachment(stream, fileName, resolvedContentType);
+    }
+
+
+
+    /// <summary>
+    /// Creates an <see cref="Attachment"/> from a base64-encoded string with automatic content type inference.
+    /// </summary>
+    /// <param name="base64Content">The attachment content as a base64-encoded string.</param>
+    /// <param name="fileName">The file name for the attachment (used for content type inference and display).</param>
+    /// <param name="contentType">Optional explicit content type. When <c>null</c>, inferred from <paramref name="fileName"/>.</param>
+    /// <returns>A new <see cref="Attachment"/> backed by a <see cref="MemoryStream"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="base64Content"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="fileName"/> is null.</exception>
+    /// <exception cref="FormatException"><paramref name="base64Content"/> is not valid base64.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public static Attachment FromBase64
+    (
+        string base64Content,
+        string fileName,
+        string? contentType = null
+    )
+    {
+        if (base64Content == null)
+        {
+            throw new ArgumentNullException(nameof(base64Content));
+        }
+
+        if (fileName == null)
+        {
+            throw new ArgumentNullException(nameof(fileName));
+        }
+
+        var bytes = Convert.FromBase64String(base64Content);
+        return FromBytes(bytes, fileName, contentType);
+    }
+
+
+
+    /// <summary>
+    /// Creates an <see cref="Attachment"/> from a <see cref="Stream"/> with automatic content type inference.
+    /// The stream content is copied to a new <see cref="MemoryStream"/>; the original stream is not modified.
+    /// </summary>
+    /// <param name="content">The stream containing the attachment content.</param>
+    /// <param name="fileName">The file name for the attachment (used for content type inference and display).</param>
+    /// <param name="contentType">Optional explicit content type. When <c>null</c>, inferred from <paramref name="fileName"/>.</param>
+    /// <returns>A new <see cref="Attachment"/> backed by a <see cref="MemoryStream"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="content"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="fileName"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public static Attachment FromStream
+    (
+        Stream content,
+        string fileName,
+        string? contentType = null
+    )
+    {
+        if (content == null)
+        {
+            throw new ArgumentNullException(nameof(content));
+        }
+
+        if (fileName == null)
+        {
+            throw new ArgumentNullException(nameof(fileName));
+        }
+
+        var destination = new MemoryStream();
+
+#pragma warning disable RS0030 // In-memory stream copy; sync is appropriate
+        if (content.CanSeek)
+        {
+            var originalPosition = content.Position;
+            content.Position = 0;
+            content.CopyTo(destination);
+            content.Position = originalPosition;
+        }
+        else
+        {
+            content.CopyTo(destination);
+        }
+#pragma warning restore RS0030
+
+        destination.Position = 0;
+        var resolvedContentType = ResolveContentType(fileName, contentType);
+
+        return new Attachment(destination, fileName, resolvedContentType);
+    }
+
+
+
+    /// <summary>
+    /// Infers the MIME content type from a file name extension.
+    /// Returns <c>application/octet-stream</c> for unknown extensions.
+    /// </summary>
+    /// <param name="fileName">The file name to infer the content type from.</param>
+    /// <returns>The inferred MIME content type string.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="fileName"/> is null.</exception>
+    // ReSharper disable once MemberCanBePrivate.Global
+    public static string InferContentType
+    (
+        string fileName
+    )
+    {
+        if (fileName == null)
+        {
+            throw new ArgumentNullException(nameof(fileName));
+        }
+
+        var extension = Path.GetExtension(fileName);
+
+        if (!string.IsNullOrEmpty(extension) && ContentTypeMap.TryGetValue(extension, out var mapped))
+        {
+            return mapped;
+        }
+
+        return MediaTypeNames.Application.Octet;
+    }
+
+
+
+    private static string ResolveContentType
+    (
+        string fileName,
+        string? explicitContentType
+    )
+    {
+        return explicitContentType ?? InferContentType(fileName);
+    }
+}

--- a/src/Wolfgang.Extensions.Mail/AttachmentFactory.cs
+++ b/src/Wolfgang.Extensions.Mail/AttachmentFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Mail;
@@ -15,42 +16,122 @@ namespace Wolfgang.Extensions.Mail;
 public static class AttachmentFactory
 {
 
-    private static readonly Dictionary<string, string> ContentTypeMap = new Dictionary<string, string>
+    private static readonly ConcurrentDictionary<string, string> ContentTypeMap =
+        new ConcurrentDictionary<string, string>
+        (
+            new[]
+            {
+                new KeyValuePair<string, string>(".pdf", "application/pdf"),
+                new KeyValuePair<string, string>(".zip", "application/zip"),
+                new KeyValuePair<string, string>(".gz", "application/gzip"),
+                new KeyValuePair<string, string>(".json", "application/json"),
+                new KeyValuePair<string, string>(".xml", "application/xml"),
+                new KeyValuePair<string, string>(".doc", "application/msword"),
+                new KeyValuePair<string, string>(".docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+                new KeyValuePair<string, string>(".xls", "application/vnd.ms-excel"),
+                new KeyValuePair<string, string>(".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+                new KeyValuePair<string, string>(".ppt", "application/vnd.ms-powerpoint"),
+                new KeyValuePair<string, string>(".pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"),
+                new KeyValuePair<string, string>(".png", "image/png"),
+                new KeyValuePair<string, string>(".jpg", "image/jpeg"),
+                new KeyValuePair<string, string>(".jpeg", "image/jpeg"),
+                new KeyValuePair<string, string>(".gif", "image/gif"),
+                new KeyValuePair<string, string>(".svg", "image/svg+xml"),
+                new KeyValuePair<string, string>(".bmp", "image/bmp"),
+                new KeyValuePair<string, string>(".ico", "image/x-icon"),
+                new KeyValuePair<string, string>(".webp", "image/webp"),
+                new KeyValuePair<string, string>(".txt", "text/plain"),
+                new KeyValuePair<string, string>(".csv", "text/csv"),
+                new KeyValuePair<string, string>(".html", "text/html"),
+                new KeyValuePair<string, string>(".htm", "text/html"),
+                new KeyValuePair<string, string>(".css", "text/css"),
+                new KeyValuePair<string, string>(".js", "text/javascript"),
+                new KeyValuePair<string, string>(".mp3", "audio/mpeg"),
+                new KeyValuePair<string, string>(".wav", "audio/wav"),
+                new KeyValuePair<string, string>(".mp4", "video/mp4"),
+                new KeyValuePair<string, string>(".avi", "video/x-msvideo"),
+                new KeyValuePair<string, string>(".eml", "message/rfc822"),
+            },
+            StringComparer.OrdinalIgnoreCase
+        );
+
+
+
+    /// <summary>
+    /// Registers or overrides a custom content type mapping for a file extension.
+    /// Extension matching is case-insensitive. Registrations persist for the lifetime of the process.
+    /// </summary>
+    /// <param name="extension">The file extension (with leading dot, e.g. <c>".heic"</c>).</param>
+    /// <param name="contentType">The MIME content type to associate with the extension.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="extension"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="contentType"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="extension"/> is empty or does not start with <c>"."</c>.</exception>
+    /// <example>
+    /// <code>
+    /// AttachmentFactory.RegisterContentType(".heic", "image/heic");
+    /// var attachment = AttachmentFactory.FromBytes(data, "photo.heic");
+    /// // attachment.ContentType.MediaType == "image/heic"
+    /// </code>
+    /// </example>
+    // ReSharper disable once UnusedMember.Global
+    public static void RegisterContentType
     (
-        StringComparer.OrdinalIgnoreCase
+        string extension,
+        string contentType
     )
     {
-        { ".pdf", "application/pdf" },
-        { ".zip", "application/zip" },
-        { ".gz", "application/gzip" },
-        { ".json", "application/json" },
-        { ".xml", "application/xml" },
-        { ".doc", "application/msword" },
-        { ".docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document" },
-        { ".xls", "application/vnd.ms-excel" },
-        { ".xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" },
-        { ".ppt", "application/vnd.ms-powerpoint" },
-        { ".pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation" },
-        { ".png", "image/png" },
-        { ".jpg", "image/jpeg" },
-        { ".jpeg", "image/jpeg" },
-        { ".gif", "image/gif" },
-        { ".svg", "image/svg+xml" },
-        { ".bmp", "image/bmp" },
-        { ".ico", "image/x-icon" },
-        { ".webp", "image/webp" },
-        { ".txt", "text/plain" },
-        { ".csv", "text/csv" },
-        { ".html", "text/html" },
-        { ".htm", "text/html" },
-        { ".css", "text/css" },
-        { ".js", "text/javascript" },
-        { ".mp3", "audio/mpeg" },
-        { ".wav", "audio/wav" },
-        { ".mp4", "video/mp4" },
-        { ".avi", "video/x-msvideo" },
-        { ".eml", "message/rfc822" },
-    };
+        if (extension == null)
+        {
+            throw new ArgumentNullException(nameof(extension));
+        }
+
+        if (contentType == null)
+        {
+            throw new ArgumentNullException(nameof(contentType));
+        }
+
+        if (extension.Length == 0 || extension[0] != '.')
+        {
+            throw new ArgumentException
+            (
+                "Extension must start with '.' (for example, \".heic\").",
+                nameof(extension)
+            );
+        }
+
+        ContentTypeMap[extension] = contentType;
+    }
+
+
+
+    /// <summary>
+    /// Attempts to retrieve the registered content type for a file extension.
+    /// </summary>
+    /// <param name="extension">The file extension (with leading dot).</param>
+    /// <param name="contentType">When this method returns, contains the registered content type if found; otherwise, <c>null</c>.</param>
+    /// <returns><c>true</c> if a content type was registered for the extension; otherwise, <c>false</c>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="extension"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public static bool TryGetRegisteredContentType
+    (
+        string extension,
+        out string? contentType
+    )
+    {
+        if (extension == null)
+        {
+            throw new ArgumentNullException(nameof(extension));
+        }
+
+        if (ContentTypeMap.TryGetValue(extension, out var value))
+        {
+            contentType = value;
+            return true;
+        }
+
+        contentType = null;
+        return false;
+    }
 
 
 

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/AttachmentFactoryTests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/AttachmentFactoryTests.cs
@@ -1,0 +1,193 @@
+using System;
+using System.IO;
+using System.Net.Mail;
+using Xunit;
+using Assert = Xunit.Assert;
+#pragma warning disable CA1707
+
+namespace Wolfgang.Extensions.Mail.Tests.Unit;
+
+public class AttachmentFactoryTests
+{
+    // ---------- FromBytes ----------
+
+    [Fact]
+    public void FromBytes_when_content_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => AttachmentFactory.FromBytes(null!, "test.bin")
+        );
+        Assert.Equal("content", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void FromBytes_when_fileName_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => AttachmentFactory.FromBytes(new byte[] { 1 }, null!)
+        );
+        Assert.Equal("fileName", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void FromBytes_when_valid_creates_attachment_with_inferred_content_type()
+    {
+        using var attachment = AttachmentFactory.FromBytes
+        (
+            new byte[] { 1, 2, 3 },
+            "report.pdf"
+        );
+
+        Assert.Equal("report.pdf", attachment.Name);
+        Assert.Equal("application/pdf", attachment.ContentType.MediaType);
+        Assert.Equal(3, attachment.ContentStream.Length);
+    }
+
+
+
+    [Fact]
+    public void FromBytes_when_explicit_content_type_uses_override()
+    {
+        using var attachment = AttachmentFactory.FromBytes
+        (
+            new byte[] { 1 },
+            "data.bin",
+            "application/custom"
+        );
+
+        Assert.Equal("application/custom", attachment.ContentType.MediaType);
+    }
+
+
+
+    // ---------- FromBase64 ----------
+
+    [Fact]
+    public void FromBase64_when_base64Content_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => AttachmentFactory.FromBase64(null!, "test.bin")
+        );
+        Assert.Equal("base64Content", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void FromBase64_when_invalid_base64_throws_FormatException()
+    {
+        Assert.Throws<FormatException>
+        (
+            () => AttachmentFactory.FromBase64("not-valid-base64!!!", "test.bin")
+        );
+    }
+
+
+
+    [Fact]
+    public void FromBase64_when_valid_creates_attachment_with_decoded_content()
+    {
+        var original = new byte[] { 10, 20, 30 };
+        var base64 = Convert.ToBase64String(original);
+
+        using var attachment = AttachmentFactory.FromBase64(base64, "image.png");
+
+        Assert.Equal("image.png", attachment.Name);
+        Assert.Equal("image/png", attachment.ContentType.MediaType);
+        Assert.Equal(3, attachment.ContentStream.Length);
+    }
+
+
+
+    // ---------- FromStream ----------
+
+    [Fact]
+    public void FromStream_when_content_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => AttachmentFactory.FromStream(null!, "test.bin")
+        );
+        Assert.Equal("content", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void FromStream_when_fileName_is_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => AttachmentFactory.FromStream(new MemoryStream(), null!)
+        );
+        Assert.Equal("fileName", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void FromStream_when_valid_copies_stream_content()
+    {
+        var original = new byte[] { 1, 2, 3, 4, 5 };
+        using var stream = new MemoryStream(original);
+
+        using var attachment = AttachmentFactory.FromStream(stream, "data.xlsx");
+
+        Assert.Equal("data.xlsx", attachment.Name);
+        Assert.Equal("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", attachment.ContentType.MediaType);
+        Assert.Equal(5, attachment.ContentStream.Length);
+    }
+
+
+
+    [Fact]
+    public void FromStream_does_not_modify_original_stream_position()
+    {
+        using var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        stream.Position = 2;
+
+        using var attachment = AttachmentFactory.FromStream(stream, "test.bin");
+
+        Assert.Equal(2, stream.Position);
+    }
+
+
+
+    // ---------- InferContentType ----------
+
+    [Theory]
+    [InlineData("file.pdf", "application/pdf")]
+    [InlineData("file.PDF", "application/pdf")]
+    [InlineData("file.png", "image/png")]
+    [InlineData("file.jpg", "image/jpeg")]
+    [InlineData("file.csv", "text/csv")]
+    [InlineData("file.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document")]
+    [InlineData("file.unknown", "application/octet-stream")]
+    [InlineData("file", "application/octet-stream")]
+    public void InferContentType_when_given_filename_returns_expected_type
+    (
+        string fileName,
+        string expectedType
+    )
+    {
+        Assert.Equal(expectedType, AttachmentFactory.InferContentType(fileName));
+    }
+
+
+
+    [Fact]
+    public void InferContentType_when_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => AttachmentFactory.InferContentType(null!)
+        );
+    }
+}

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/AttachmentFactoryTests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/AttachmentFactoryTests.cs
@@ -190,4 +190,121 @@ public class AttachmentFactoryTests
             () => AttachmentFactory.InferContentType(null!)
         );
     }
+
+
+
+    // ---------- RegisterContentType ----------
+
+    [Fact]
+    public void RegisterContentType_when_extension_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => AttachmentFactory.RegisterContentType(null!, "application/custom")
+        );
+        Assert.Equal("extension", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void RegisterContentType_when_contentType_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => AttachmentFactory.RegisterContentType(".custom", null!)
+        );
+        Assert.Equal("contentType", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void RegisterContentType_when_extension_does_not_start_with_dot_throws_ArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>
+        (
+            () => AttachmentFactory.RegisterContentType("heic", "image/heic")
+        );
+        Assert.Equal("extension", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void RegisterContentType_when_extension_empty_throws_ArgumentException()
+    {
+        Assert.Throws<ArgumentException>
+        (
+            () => AttachmentFactory.RegisterContentType("", "application/custom")
+        );
+    }
+
+
+
+    [Fact]
+    public void RegisterContentType_when_registered_InferContentType_returns_it()
+    {
+        AttachmentFactory.RegisterContentType(".test1", "application/x-test1");
+
+        Assert.Equal("application/x-test1", AttachmentFactory.InferContentType("file.test1"));
+    }
+
+
+
+    [Fact]
+    public void RegisterContentType_when_extension_already_exists_overrides_it()
+    {
+        AttachmentFactory.RegisterContentType(".test2", "application/x-test2-original");
+        AttachmentFactory.RegisterContentType(".test2", "application/x-test2-override");
+
+        Assert.Equal("application/x-test2-override", AttachmentFactory.InferContentType("file.test2"));
+    }
+
+
+
+    [Fact]
+    public void RegisterContentType_extension_matching_is_case_insensitive()
+    {
+        AttachmentFactory.RegisterContentType(".test3", "application/x-test3");
+
+        Assert.Equal("application/x-test3", AttachmentFactory.InferContentType("file.TEST3"));
+    }
+
+
+
+    // ---------- TryGetRegisteredContentType ----------
+
+    [Fact]
+    public void TryGetRegisteredContentType_when_extension_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => AttachmentFactory.TryGetRegisteredContentType(null!, out _)
+        );
+    }
+
+
+
+    [Fact]
+    public void TryGetRegisteredContentType_when_registered_returns_true()
+    {
+        AttachmentFactory.RegisterContentType(".test4", "application/x-test4");
+
+        var success = AttachmentFactory.TryGetRegisteredContentType(".test4", out var contentType);
+
+        Assert.True(success);
+        Assert.Equal("application/x-test4", contentType);
+    }
+
+
+
+    [Fact]
+    public void TryGetRegisteredContentType_when_not_registered_returns_false()
+    {
+        var success = AttachmentFactory.TryGetRegisteredContentType(".nonexistent-ext-xyz", out var contentType);
+
+        Assert.False(success);
+        Assert.Null(contentType);
+    }
 }


### PR DESCRIPTION
## Summary
- `FromBytes(byte[], string, string?)` — create attachment from byte array
- `FromBase64(string, string, string?)` — create from base64 string
- `FromStream(Stream, string, string?)` — create from stream (copies content)
- `InferContentType(string)` — MIME type inference from 30+ extensions
- All methods support explicit content type override

Closes #23

## Test plan
- [x] 20 tests pass on net10.0
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)