### PR TITLE
Add InlineHtmlBuilder for inline image embedding

### DIFF
--- a/src/Wolfgang.Extensions.Mail/InlineHtmlBuilder.cs
+++ b/src/Wolfgang.Extensions.Mail/InlineHtmlBuilder.cs
@@ -214,7 +214,7 @@ public sealed class InlineHtmlBuilder
             );
         }
 
-        var html = string.Format(_htmlTemplate, _contentIds.ToArray());
+        var html = string.Format(System.Globalization.CultureInfo.InvariantCulture, _htmlTemplate, _contentIds.ToArray());
 
         var view = AlternateView.CreateAlternateViewFromString
         (

--- a/src/Wolfgang.Extensions.Mail/InlineHtmlBuilder.cs
+++ b/src/Wolfgang.Extensions.Mail/InlineHtmlBuilder.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Mail;
+using System.Net.Mime;
+
+namespace Wolfgang.Extensions.Mail;
+
+
+/// <summary>
+/// A builder for creating HTML <see cref="AlternateView"/> instances with inline embedded images.
+/// Manages <see cref="LinkedResource"/> creation and Content-ID wiring automatically.
+/// </summary>
+/// <example>
+/// <code>
+/// var builder = new InlineHtmlBuilder()
+///     .Html("&lt;h1&gt;Report&lt;/h1&gt;&lt;img src='cid:{0}' /&gt;")
+///     .EmbedImage("chart.png");
+///
+/// message.AlternateViews.Add(builder.Build());
+/// </code>
+/// </example>
+// ReSharper disable once UnusedType.Global
+public sealed class InlineHtmlBuilder
+{
+
+    private string? _htmlTemplate;
+    private readonly List<LinkedResource> _resources = new List<LinkedResource>();
+    private readonly List<string> _contentIds = new List<string>();
+
+
+
+    /// <summary>
+    /// Sets the HTML template. Use <c>{0}</c>, <c>{1}</c>, etc. as placeholders for
+    /// embedded image Content-IDs, which are filled in order of <see cref="EmbedImage(string)"/> calls.
+    /// </summary>
+    /// <param name="htmlTemplate">The HTML template string with <c>{n}</c> placeholders for inline images.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="htmlTemplate"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public InlineHtmlBuilder Html
+    (
+        string htmlTemplate
+    )
+    {
+        if (htmlTemplate == null)
+        {
+            throw new ArgumentNullException(nameof(htmlTemplate));
+        }
+
+        _htmlTemplate = htmlTemplate;
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Embeds an image from a file path as a <see cref="LinkedResource"/>.
+    /// The content type is inferred from the file extension.
+    /// </summary>
+    /// <param name="filePath">The path to the image file.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="filePath"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public InlineHtmlBuilder EmbedImage
+    (
+        string filePath
+    )
+    {
+        if (filePath == null)
+        {
+            throw new ArgumentNullException(nameof(filePath));
+        }
+
+        var contentType = InferImageContentType(Path.GetExtension(filePath));
+        var contentId = GenerateContentId();
+
+#pragma warning disable RS0030 // File I/O — reading image file into memory for embedding
+        var bytes = File.ReadAllBytes(filePath);
+#pragma warning restore RS0030
+
+        var stream = new MemoryStream(bytes, writable: false);
+        var resource = new LinkedResource(stream, contentType)
+        {
+            ContentId = contentId
+        };
+
+        _resources.Add(resource);
+        _contentIds.Add(contentId);
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Embeds an image from a <see cref="Stream"/> as a <see cref="LinkedResource"/>.
+    /// The stream content is copied; the original stream is not modified.
+    /// </summary>
+    /// <param name="imageStream">The stream containing the image data.</param>
+    /// <param name="fileName">A file name used for content type inference (e.g., <c>"logo.png"</c>).</param>
+    /// <param name="contentType">Optional explicit content type. When <c>null</c>, inferred from <paramref name="fileName"/>.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="imageStream"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="fileName"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public InlineHtmlBuilder EmbedImage
+    (
+        Stream imageStream,
+        string fileName,
+        string? contentType = null
+    )
+    {
+        if (imageStream == null)
+        {
+            throw new ArgumentNullException(nameof(imageStream));
+        }
+
+        if (fileName == null)
+        {
+            throw new ArgumentNullException(nameof(fileName));
+        }
+
+        var resolvedContentType = contentType ?? InferImageContentType(Path.GetExtension(fileName));
+        var contentId = GenerateContentId();
+
+        var destination = new MemoryStream();
+
+#pragma warning disable RS0030 // In-memory stream copy
+        if (imageStream.CanSeek)
+        {
+            var originalPosition = imageStream.Position;
+            imageStream.Position = 0;
+            imageStream.CopyTo(destination);
+            imageStream.Position = originalPosition;
+        }
+        else
+        {
+            imageStream.CopyTo(destination);
+        }
+#pragma warning restore RS0030
+
+        destination.Position = 0;
+
+        var resource = new LinkedResource(destination, resolvedContentType)
+        {
+            ContentId = contentId
+        };
+
+        _resources.Add(resource);
+        _contentIds.Add(contentId);
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Embeds an image from a byte array as a <see cref="LinkedResource"/>.
+    /// </summary>
+    /// <param name="imageBytes">The image content as a byte array.</param>
+    /// <param name="fileName">A file name used for content type inference (e.g., <c>"chart.png"</c>).</param>
+    /// <param name="contentType">Optional explicit content type. When <c>null</c>, inferred from <paramref name="fileName"/>.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="imageBytes"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="fileName"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public InlineHtmlBuilder EmbedImage
+    (
+        byte[] imageBytes,
+        string fileName,
+        string? contentType = null
+    )
+    {
+        if (imageBytes == null)
+        {
+            throw new ArgumentNullException(nameof(imageBytes));
+        }
+
+        if (fileName == null)
+        {
+            throw new ArgumentNullException(nameof(fileName));
+        }
+
+        var resolvedContentType = contentType ?? InferImageContentType(Path.GetExtension(fileName));
+        var contentId = GenerateContentId();
+        var stream = new MemoryStream(imageBytes, writable: false);
+
+        var resource = new LinkedResource(stream, resolvedContentType)
+        {
+            ContentId = contentId
+        };
+
+        _resources.Add(resource);
+        _contentIds.Add(contentId);
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Builds the <see cref="AlternateView"/> with all embedded images wired up.
+    /// The HTML template placeholders (<c>{0}</c>, <c>{1}</c>, etc.) are replaced with
+    /// the generated Content-IDs.
+    /// </summary>
+    /// <returns>An <see cref="AlternateView"/> containing the HTML and all linked resources.</returns>
+    /// <exception cref="InvalidOperationException">No HTML template has been set via <see cref="Html"/>.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public AlternateView Build()
+    {
+        if (_htmlTemplate == null)
+        {
+            throw new InvalidOperationException
+            (
+                "An HTML template must be set via Html() before calling Build()."
+            );
+        }
+
+        var html = string.Format(_htmlTemplate, _contentIds.ToArray());
+
+        var view = AlternateView.CreateAlternateViewFromString
+        (
+            html,
+            null,
+            MediaTypeNames.Text.Html
+        );
+
+        foreach (var resource in _resources)
+        {
+            view.LinkedResources.Add(resource);
+        }
+
+        return view;
+    }
+
+
+
+    private static string GenerateContentId()
+    {
+        return Guid.NewGuid().ToString("N");
+    }
+
+
+
+    private static string InferImageContentType
+    (
+        string extension
+    )
+    {
+        switch (extension.ToLowerInvariant())
+        {
+            case ".png": return "image/png";
+            case ".jpg":
+            case ".jpeg": return "image/jpeg";
+            case ".gif": return "image/gif";
+            case ".bmp": return "image/bmp";
+            case ".svg": return "image/svg+xml";
+            case ".webp": return "image/webp";
+            case ".ico": return "image/x-icon";
+            default: return MediaTypeNames.Application.Octet;
+        }
+    }
+}

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/InlineHtmlBuilderTests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/InlineHtmlBuilderTests.cs
@@ -295,6 +295,14 @@ public class InlineHtmlBuilderTests
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
         public override void SetLength(long value) => throw new NotSupportedException();
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
-        protected override void Dispose(bool disposing) { if (disposing) _inner.Dispose(); base.Dispose(disposing); }
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
     }
 }

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/InlineHtmlBuilderTests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/InlineHtmlBuilderTests.cs
@@ -172,4 +172,129 @@ public class InlineHtmlBuilderTests
 
         Assert.Equal("image/custom", view.LinkedResources[0].ContentType.MediaType);
     }
+
+
+
+    // ---------- EmbedImage(string filePath) ----------
+
+    [Fact]
+    public void EmbedImage_filePath_when_null_throws_ArgumentNullException()
+    {
+        var builder = new InlineHtmlBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.EmbedImage((string)null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void EmbedImage_filePath_reads_file_and_infers_content_type()
+    {
+        var filePath = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid():N}.png");
+        File.WriteAllBytes(filePath, new byte[] { 1, 2, 3, 4 });
+
+        try
+        {
+            var builder = new InlineHtmlBuilder()
+                .Html("<img src='cid:{0}' />")
+                .EmbedImage(filePath);
+
+            using var view = builder.Build();
+
+            Assert.Single(view.LinkedResources);
+            Assert.Equal("image/png", view.LinkedResources[0].ContentType.MediaType);
+        }
+        finally
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+    }
+
+
+
+    // ---------- EmbedImage stream/bytes null guards ----------
+
+    [Fact]
+    public void EmbedImage_stream_when_fileName_is_null_throws_ArgumentNullException()
+    {
+        var builder = new InlineHtmlBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.EmbedImage(new MemoryStream(), null!)
+        );
+    }
+
+
+
+    // ---------- EmbedImage stream non-seekable ----------
+
+    [Fact]
+    public void EmbedImage_stream_when_non_seekable_copies_content()
+    {
+        var seekable = new MemoryStream(new byte[] { 1, 2, 3 });
+        using var nonSeekable = new NonSeekableStream(seekable);
+
+        var builder = new InlineHtmlBuilder()
+            .Html("<img src='cid:{0}' />")
+            .EmbedImage(nonSeekable, "image.png");
+
+        using var view = builder.Build();
+
+        Assert.Single(view.LinkedResources);
+        Assert.Equal(3, view.LinkedResources[0].ContentStream.Length);
+    }
+
+
+
+    // ---------- InferImageContentType coverage ----------
+
+    [Theory]
+    [InlineData("image.gif", "image/gif")]
+    [InlineData("image.svg", "image/svg+xml")]
+    [InlineData("image.bmp", "image/bmp")]
+    [InlineData("image.webp", "image/webp")]
+    [InlineData("image.ico", "image/x-icon")]
+    [InlineData("image.unknown", "application/octet-stream")]
+    public void EmbedImage_infers_content_type_from_extension
+    (
+        string fileName,
+        string expectedType
+    )
+    {
+        var builder = new InlineHtmlBuilder()
+            .Html("<img src='cid:{0}' />")
+            .EmbedImage(new byte[] { 1 }, fileName);
+
+        using var view = builder.Build();
+
+        Assert.Equal(expectedType, view.LinkedResources[0].ContentType.MediaType);
+    }
+
+
+
+    // ---------- Helper ----------
+
+    private sealed class NonSeekableStream : Stream
+    {
+        private readonly Stream _inner;
+        public NonSeekableStream(Stream inner) { _inner = inner; _inner.Position = 0; }
+        public override bool CanRead => _inner.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => _inner.Position; set => throw new NotSupportedException(); }
+        public override void Flush() => _inner.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        protected override void Dispose(bool disposing) { if (disposing) _inner.Dispose(); base.Dispose(disposing); }
+    }
 }

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/InlineHtmlBuilderTests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/InlineHtmlBuilderTests.cs
@@ -5,6 +5,7 @@ using System.Net.Mail;
 using Xunit;
 using Assert = Xunit.Assert;
 #pragma warning disable CA1707
+#pragma warning disable MA0074 // xUnit Assert.Contains/DoesNotContain triggers this for string overloads
 
 namespace Wolfgang.Extensions.Mail.Tests.Unit;
 
@@ -48,7 +49,7 @@ public class InlineHtmlBuilderTests
 
         using var view = builder.Build();
 
-        Assert.Equal(0, view.LinkedResources.Count);
+        Assert.Empty(view.LinkedResources);
         Assert.Contains("text/html", view.ContentType.MediaType);
     }
 
@@ -91,7 +92,7 @@ public class InlineHtmlBuilderTests
 
         using var view = builder.Build();
 
-        Assert.Equal(1, view.LinkedResources.Count);
+        Assert.Single(view.LinkedResources);
         Assert.False(string.IsNullOrEmpty(view.LinkedResources[0].ContentId));
         Assert.Equal("image/png", view.LinkedResources[0].ContentType.MediaType);
     }
@@ -127,7 +128,7 @@ public class InlineHtmlBuilderTests
 
         using var view = builder.Build();
 
-        Assert.Equal(1, view.LinkedResources.Count);
+        Assert.Single(view.LinkedResources);
         Assert.Equal("image/jpeg", view.LinkedResources[0].ContentType.MediaType);
     }
 

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/InlineHtmlBuilderTests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/InlineHtmlBuilderTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Mail;
+using Xunit;
+using Assert = Xunit.Assert;
+#pragma warning disable CA1707
+
+namespace Wolfgang.Extensions.Mail.Tests.Unit;
+
+public class InlineHtmlBuilderTests
+{
+    // ---------- Html ----------
+
+    [Fact]
+    public void Html_when_null_throws_ArgumentNullException()
+    {
+        var builder = new InlineHtmlBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.Html(null!)
+        );
+    }
+
+
+
+    // ---------- Build ----------
+
+    [Fact]
+    public void Build_when_no_html_set_throws_InvalidOperationException()
+    {
+        var builder = new InlineHtmlBuilder();
+
+        Assert.Throws<InvalidOperationException>
+        (
+            () => builder.Build()
+        );
+    }
+
+
+
+    [Fact]
+    public void Build_when_html_only_returns_alternate_view_with_no_resources()
+    {
+        var builder = new InlineHtmlBuilder()
+            .Html("<h1>Hello</h1>");
+
+        using var view = builder.Build();
+
+        Assert.Equal(0, view.LinkedResources.Count);
+        Assert.Contains("text/html", view.ContentType.MediaType);
+    }
+
+
+
+    // ---------- EmbedImage(byte[], string) ----------
+
+    [Fact]
+    public void EmbedImage_bytes_when_null_bytes_throws_ArgumentNullException()
+    {
+        var builder = new InlineHtmlBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.EmbedImage((byte[])null!, "img.png")
+        );
+    }
+
+
+
+    [Fact]
+    public void EmbedImage_bytes_when_null_fileName_throws_ArgumentNullException()
+    {
+        var builder = new InlineHtmlBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.EmbedImage(new byte[] { 1 }, null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void EmbedImage_bytes_creates_linked_resource_with_content_id()
+    {
+        var builder = new InlineHtmlBuilder()
+            .Html("<img src='cid:{0}' />")
+            .EmbedImage(new byte[] { 1, 2, 3 }, "chart.png");
+
+        using var view = builder.Build();
+
+        Assert.Equal(1, view.LinkedResources.Count);
+        Assert.False(string.IsNullOrEmpty(view.LinkedResources[0].ContentId));
+        Assert.Equal("image/png", view.LinkedResources[0].ContentType.MediaType);
+    }
+
+
+
+    // ---------- EmbedImage(Stream, string) ----------
+
+    [Fact]
+    public void EmbedImage_stream_when_null_stream_throws_ArgumentNullException()
+    {
+        var builder = new InlineHtmlBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.EmbedImage((Stream)null!, "img.png")
+        );
+    }
+
+
+
+    [Fact]
+    public void EmbedImage_stream_copies_content_and_preserves_original_position()
+    {
+        using var stream = new MemoryStream(new byte[] { 10, 20, 30 });
+        stream.Position = 2;
+
+        var builder = new InlineHtmlBuilder()
+            .Html("<img src='cid:{0}' />")
+            .EmbedImage(stream, "logo.jpg");
+
+        Assert.Equal(2, stream.Position);
+
+        using var view = builder.Build();
+
+        Assert.Equal(1, view.LinkedResources.Count);
+        Assert.Equal("image/jpeg", view.LinkedResources[0].ContentType.MediaType);
+    }
+
+
+
+    // ---------- Multiple images ----------
+
+    [Fact]
+    public void Build_when_multiple_images_replaces_all_placeholders()
+    {
+        var builder = new InlineHtmlBuilder()
+            .Html("<img src='cid:{0}' /><img src='cid:{1}' />")
+            .EmbedImage(new byte[] { 1 }, "a.png")
+            .EmbedImage(new byte[] { 2 }, "b.jpg");
+
+        using var view = builder.Build();
+
+        Assert.Equal(2, view.LinkedResources.Count);
+
+        // Verify the HTML contains the content IDs (not the placeholders)
+        using var reader = new StreamReader(view.ContentStream);
+        var html = reader.ReadToEnd();
+        Assert.DoesNotContain("{0}", html);
+        Assert.DoesNotContain("{1}", html);
+        Assert.Contains(view.LinkedResources[0].ContentId, html);
+        Assert.Contains(view.LinkedResources[1].ContentId, html);
+    }
+
+
+
+    // ---------- Content type inference ----------
+
+    [Fact]
+    public void EmbedImage_bytes_when_explicit_content_type_uses_override()
+    {
+        var builder = new InlineHtmlBuilder()
+            .Html("<img src='cid:{0}' />")
+            .EmbedImage(new byte[] { 1 }, "img.dat", "image/custom");
+
+        using var view = builder.Build();
+
+        Assert.Equal("image/custom", view.LinkedResources[0].ContentType.MediaType);
+    }
+}


### PR DESCRIPTION
## Summary
- `InlineHtmlBuilder` — fluent builder for HTML emails with embedded images
- `.Html(template)` → `.EmbedImage(...)` → `.Build()` produces an `AlternateView` with wired `LinkedResource` objects
- Supports file path, Stream, and byte[] image sources
- Auto-generates Content-IDs, infers content types from extensions

Closes #28

## Test plan
- [x] 10 tests pass on net10.0
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)