### PR TITLE
Add FluentMailMessageBuilder

### DIFF
--- a/src/Wolfgang.Extensions.Mail/MailMessageBuilder.cs
+++ b/src/Wolfgang.Extensions.Mail/MailMessageBuilder.cs
@@ -1,0 +1,564 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Mail;
+using System.Net.Mime;
+using System.Text;
+
+namespace Wolfgang.Extensions.Mail;
+
+
+/// <summary>
+/// A fluent builder for constructing <see cref="MailMessage"/> instances.
+/// Simplifies the verbose ceremony of setting up mail messages.
+/// </summary>
+/// <example>
+/// <code>
+/// using var message = new MailMessageBuilder()
+///     .From("sender@example.com", "Sender Name")
+///     .To("alice@example.com", "bob@example.com")
+///     .Subject("Monthly Report")
+///     .HtmlBody("&lt;h1&gt;Report&lt;/h1&gt;")
+///     .Attach("report.pdf")
+///     .Build();
+/// </code>
+/// </example>
+// ReSharper disable once UnusedType.Global
+public sealed class MailMessageBuilder
+{
+
+    private MailAddress? _from;
+    private MailAddress? _sender;
+    private readonly List<MailAddress> _to = new List<MailAddress>();
+    private readonly List<MailAddress> _cc = new List<MailAddress>();
+    private readonly List<MailAddress> _bcc = new List<MailAddress>();
+    private readonly List<MailAddress> _replyTo = new List<MailAddress>();
+    private string? _subject;
+    private string? _textBody;
+    private string? _htmlBody;
+    private MailPriority _priority = MailPriority.Normal;
+    private readonly List<Attachment> _attachments = new List<Attachment>();
+    private readonly Dictionary<string, string> _headers = new Dictionary<string, string>();
+    private Encoding? _bodyEncoding;
+    private Encoding? _subjectEncoding;
+    private DeliveryNotificationOptions _deliveryNotification = DeliveryNotificationOptions.None;
+
+
+
+    /// <summary>
+    /// Sets the From address.
+    /// </summary>
+    /// <param name="address">The sender email address.</param>
+    /// <param name="displayName">Optional display name.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="address"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder From
+    (
+        string address,
+        string? displayName = null
+    )
+    {
+        if (address == null)
+        {
+            throw new ArgumentNullException(nameof(address));
+        }
+
+        _from = string.IsNullOrEmpty(displayName)
+            ? new MailAddress(address)
+            : new MailAddress(address, displayName);
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Sets the Sender address (the actual sender, if different from From).
+    /// </summary>
+    /// <param name="address">The sender email address.</param>
+    /// <param name="displayName">Optional display name.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="address"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder SenderAddress
+    (
+        string address,
+        string? displayName = null
+    )
+    {
+        if (address == null)
+        {
+            throw new ArgumentNullException(nameof(address));
+        }
+
+        _sender = string.IsNullOrEmpty(displayName)
+            ? new MailAddress(address)
+            : new MailAddress(address, displayName);
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Adds one or more To recipients.
+    /// </summary>
+    /// <param name="addresses">The recipient email addresses.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="addresses"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder To
+    (
+        params string[] addresses
+    )
+    {
+        if (addresses == null)
+        {
+            throw new ArgumentNullException(nameof(addresses));
+        }
+
+        foreach (var addr in addresses)
+        {
+            _to.Add(new MailAddress(addr));
+        }
+
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Adds a To recipient with a display name.
+    /// </summary>
+    /// <param name="address">The recipient email address.</param>
+    /// <param name="displayName">The display name.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="address"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder To
+    (
+        string address,
+        string displayName
+    )
+    {
+        if (address == null)
+        {
+            throw new ArgumentNullException(nameof(address));
+        }
+
+        _to.Add(new MailAddress(address, displayName));
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Adds one or more CC recipients.
+    /// </summary>
+    /// <param name="addresses">The CC email addresses.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="addresses"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder Cc
+    (
+        params string[] addresses
+    )
+    {
+        if (addresses == null)
+        {
+            throw new ArgumentNullException(nameof(addresses));
+        }
+
+        foreach (var addr in addresses)
+        {
+            _cc.Add(new MailAddress(addr));
+        }
+
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Adds one or more BCC recipients.
+    /// </summary>
+    /// <param name="addresses">The BCC email addresses.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="addresses"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder Bcc
+    (
+        params string[] addresses
+    )
+    {
+        if (addresses == null)
+        {
+            throw new ArgumentNullException(nameof(addresses));
+        }
+
+        foreach (var addr in addresses)
+        {
+            _bcc.Add(new MailAddress(addr));
+        }
+
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Adds one or more Reply-To addresses.
+    /// </summary>
+    /// <param name="addresses">The reply-to email addresses.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="addresses"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder ReplyTo
+    (
+        params string[] addresses
+    )
+    {
+        if (addresses == null)
+        {
+            throw new ArgumentNullException(nameof(addresses));
+        }
+
+        foreach (var addr in addresses)
+        {
+            _replyTo.Add(new MailAddress(addr));
+        }
+
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Sets the subject line.
+    /// </summary>
+    /// <param name="subject">The email subject.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder Subject
+    (
+        string? subject
+    )
+    {
+        _subject = subject;
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Sets the plain text body.
+    /// </summary>
+    /// <param name="body">The plain text body content.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder PlainTextBody
+    (
+        string? body
+    )
+    {
+        _textBody = body;
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Sets the HTML body.
+    /// </summary>
+    /// <param name="body">The HTML body content.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder HtmlBody
+    (
+        string? body
+    )
+    {
+        _htmlBody = body;
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Sets the mail priority.
+    /// </summary>
+    /// <param name="priority">The priority level.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder Priority
+    (
+        MailPriority priority
+    )
+    {
+        _priority = priority;
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Sets the delivery notification options.
+    /// </summary>
+    /// <param name="options">The notification options.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder DeliveryNotification
+    (
+        DeliveryNotificationOptions options
+    )
+    {
+        _deliveryNotification = options;
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Sets the body encoding.
+    /// </summary>
+    /// <param name="encoding">The encoding for the body.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder BodyEncoding
+    (
+        Encoding encoding
+    )
+    {
+        _bodyEncoding = encoding;
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Sets the subject encoding.
+    /// </summary>
+    /// <param name="encoding">The encoding for the subject.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder SubjectEncoding
+    (
+        Encoding encoding
+    )
+    {
+        _subjectEncoding = encoding;
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Adds a custom header.
+    /// </summary>
+    /// <param name="name">The header name.</param>
+    /// <param name="value">The header value.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder Header
+    (
+        string name,
+        string value
+    )
+    {
+        if (name == null)
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        _headers[name] = value;
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Attaches a file by path.
+    /// </summary>
+    /// <param name="filePath">The file path of the attachment.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="filePath"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder Attach
+    (
+        string filePath
+    )
+    {
+        if (filePath == null)
+        {
+            throw new ArgumentNullException(nameof(filePath));
+        }
+
+        _attachments.Add(new Attachment(filePath));
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Attaches content from a stream.
+    /// </summary>
+    /// <param name="content">The stream containing the attachment content.</param>
+    /// <param name="name">The display name for the attachment.</param>
+    /// <param name="contentType">Optional MIME content type.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="content"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder Attach
+    (
+        Stream content,
+        string name,
+        string? contentType = null
+    )
+    {
+        if (content == null)
+        {
+            throw new ArgumentNullException(nameof(content));
+        }
+
+        if (name == null)
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        _attachments.Add
+        (
+            contentType != null
+                ? new Attachment(content, name, contentType)
+                : new Attachment(content, name)
+        );
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Attaches content from a byte array.
+    /// </summary>
+    /// <param name="content">The attachment content.</param>
+    /// <param name="name">The display name for the attachment.</param>
+    /// <param name="contentType">Optional MIME content type.</param>
+    /// <returns>This builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="content"/> is null.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessageBuilder Attach
+    (
+        byte[] content,
+        string name,
+        string? contentType = null
+    )
+    {
+        if (content == null)
+        {
+            throw new ArgumentNullException(nameof(content));
+        }
+
+        if (name == null)
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        var stream = new MemoryStream(content, writable: false);
+
+        _attachments.Add
+        (
+            contentType != null
+                ? new Attachment(stream, name, contentType)
+                : new Attachment(stream, name)
+        );
+        return this;
+    }
+
+
+
+    /// <summary>
+    /// Builds a new <see cref="MailMessage"/> from the configured values.
+    /// </summary>
+    /// <returns>A fully constructed <see cref="MailMessage"/>.</returns>
+    /// <exception cref="InvalidOperationException">From address has not been set.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public MailMessage Build()
+    {
+        if (_from == null)
+        {
+            throw new InvalidOperationException
+            (
+                "From address is required. Call From() before Build()."
+            );
+        }
+
+        var message = new MailMessage
+        {
+            From = _from,
+            Subject = _subject,
+            Priority = _priority,
+            DeliveryNotificationOptions = _deliveryNotification
+        };
+
+        if (_sender != null)
+        {
+            message.Sender = _sender;
+        }
+
+        if (_bodyEncoding != null)
+        {
+            message.BodyEncoding = _bodyEncoding;
+        }
+
+        if (_subjectEncoding != null)
+        {
+            message.SubjectEncoding = _subjectEncoding;
+        }
+
+        // Recipients
+        foreach (var addr in _to) { message.To.Add(addr); }
+        foreach (var addr in _cc) { message.CC.Add(addr); }
+        foreach (var addr in _bcc) { message.Bcc.Add(addr); }
+        foreach (var addr in _replyTo) { message.ReplyToList.Add(addr); }
+
+        // Body — if both HTML and plain text are set, use AlternateViews
+        if (_htmlBody != null && _textBody != null)
+        {
+            message.IsBodyHtml = false;
+            message.Body = _textBody;
+
+            var htmlView = AlternateView.CreateAlternateViewFromString
+            (
+                _htmlBody,
+                _bodyEncoding ?? Encoding.UTF8,
+                MediaTypeNames.Text.Html
+            );
+            message.AlternateViews.Add(htmlView);
+        }
+        else if (_htmlBody != null)
+        {
+            message.IsBodyHtml = true;
+            message.Body = _htmlBody;
+        }
+        else
+        {
+            message.IsBodyHtml = false;
+            message.Body = _textBody;
+        }
+
+        // Headers
+        foreach (var kvp in _headers)
+        {
+            message.Headers[kvp.Key] = kvp.Value;
+        }
+
+        // Attachments
+        foreach (var attachment in _attachments)
+        {
+            message.Attachments.Add(attachment);
+        }
+
+        return message;
+    }
+}

--- a/src/Wolfgang.Extensions.Mail/MailMessageBuilder.cs
+++ b/src/Wolfgang.Extensions.Mail/MailMessageBuilder.cs
@@ -493,6 +493,15 @@ public sealed class MailMessageBuilder
             );
         }
 
+        if (_to.Count == 0 && _cc.Count == 0 && _bcc.Count == 0)
+        {
+            throw new InvalidOperationException
+            (
+                "At least one recipient (To, Cc, or Bcc) is required. " +
+                "Call To(), Cc(), or Bcc() before Build()."
+            );
+        }
+
         var message = new MailMessage
         {
             From = _from,

--- a/src/Wolfgang.Extensions.Mail/MailMessageBuilder.cs
+++ b/src/Wolfgang.Extensions.Mail/MailMessageBuilder.cs
@@ -38,7 +38,7 @@ public sealed class MailMessageBuilder
     private string? _htmlBody;
     private MailPriority _priority = MailPriority.Normal;
     private readonly List<Attachment> _attachments = new List<Attachment>();
-    private readonly Dictionary<string, string> _headers = new Dictionary<string, string>();
+    private readonly Dictionary<string, string> _headers = new Dictionary<string, string>(StringComparer.Ordinal);
     private Encoding? _bodyEncoding;
     private Encoding? _subjectEncoding;
     private DeliveryNotificationOptions _deliveryNotification = DeliveryNotificationOptions.None;
@@ -501,28 +501,37 @@ public sealed class MailMessageBuilder
             DeliveryNotificationOptions = _deliveryNotification
         };
 
-        if (_sender != null)
-        {
-            message.Sender = _sender;
-        }
+        ApplyOptionalProperties(message);
+        ApplyRecipients(message);
+        ApplyBody(message);
+        ApplyHeadersAndAttachments(message);
 
-        if (_bodyEncoding != null)
-        {
-            message.BodyEncoding = _bodyEncoding;
-        }
+        return message;
+    }
 
-        if (_subjectEncoding != null)
-        {
-            message.SubjectEncoding = _subjectEncoding;
-        }
 
-        // Recipients
+
+    private void ApplyOptionalProperties(MailMessage message)
+    {
+        if (_sender != null) { message.Sender = _sender; }
+        if (_bodyEncoding != null) { message.BodyEncoding = _bodyEncoding; }
+        if (_subjectEncoding != null) { message.SubjectEncoding = _subjectEncoding; }
+    }
+
+
+
+    private void ApplyRecipients(MailMessage message)
+    {
         foreach (var addr in _to) { message.To.Add(addr); }
         foreach (var addr in _cc) { message.CC.Add(addr); }
         foreach (var addr in _bcc) { message.Bcc.Add(addr); }
         foreach (var addr in _replyTo) { message.ReplyToList.Add(addr); }
+    }
 
-        // Body — if both HTML and plain text are set, use AlternateViews
+
+
+    private void ApplyBody(MailMessage message)
+    {
         if (_htmlBody != null && _textBody != null)
         {
             message.IsBodyHtml = false;
@@ -546,19 +555,13 @@ public sealed class MailMessageBuilder
             message.IsBodyHtml = false;
             message.Body = _textBody;
         }
+    }
 
-        // Headers
-        foreach (var kvp in _headers)
-        {
-            message.Headers[kvp.Key] = kvp.Value;
-        }
 
-        // Attachments
-        foreach (var attachment in _attachments)
-        {
-            message.Attachments.Add(attachment);
-        }
 
-        return message;
+    private void ApplyHeadersAndAttachments(MailMessage message)
+    {
+        foreach (var kvp in _headers) { message.Headers[kvp.Key] = kvp.Value; }
+        foreach (var attachment in _attachments) { message.Attachments.Add(attachment); }
     }
 }

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/MailMessageBuilderTests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/MailMessageBuilderTests.cs
@@ -27,6 +27,47 @@ public class MailMessageBuilderTests
 
 
 
+    [Fact]
+    public void Build_when_no_recipients_throws_InvalidOperationException()
+    {
+        var builder = new MailMessageBuilder()
+            .From("from@example.com");
+
+        var ex = Assert.Throws<InvalidOperationException>
+        (
+            () => builder.Build()
+        );
+        Assert.Contains("recipient", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+
+    [Fact]
+    public void Build_when_only_Cc_recipient_is_set_succeeds()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .Cc("cc@example.com")
+            .Build();
+
+        Assert.Single(msg.CC);
+    }
+
+
+
+    [Fact]
+    public void Build_when_only_Bcc_recipient_is_set_succeeds()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .Bcc("bcc@example.com")
+            .Build();
+
+        Assert.Single(msg.Bcc);
+    }
+
+
+
     // ---------- From ----------
 
     [Fact]

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/MailMessageBuilderTests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/MailMessageBuilderTests.cs
@@ -361,4 +361,220 @@ public class MailMessageBuilderTests
         Assert.Equal("yes", msg.Headers["X-Test"]);
         Assert.Single(msg.Attachments);
     }
+
+
+
+    // ---------- Null guards ----------
+
+    [Fact]
+    public void SenderAddress_when_null_throws_ArgumentNullException()
+    {
+        var builder = new MailMessageBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.SenderAddress(null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void To_params_when_null_throws_ArgumentNullException()
+    {
+        var builder = new MailMessageBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.To((string[])null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void To_with_displayName_when_null_throws_ArgumentNullException()
+    {
+        var builder = new MailMessageBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.To(null!, "Name")
+        );
+    }
+
+
+
+    [Fact]
+    public void To_with_displayName_adds_recipient_with_name()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .To("alice@example.com", "Alice Smith")
+            .Build();
+
+        var to = Assert.Single(msg.To);
+        Assert.Equal("alice@example.com", to.Address);
+        Assert.Equal("Alice Smith", to.DisplayName);
+    }
+
+
+
+    [Fact]
+    public void Cc_when_null_throws_ArgumentNullException()
+    {
+        var builder = new MailMessageBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.Cc(null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void Bcc_when_null_throws_ArgumentNullException()
+    {
+        var builder = new MailMessageBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.Bcc(null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void ReplyTo_when_null_throws_ArgumentNullException()
+    {
+        var builder = new MailMessageBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.ReplyTo(null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void Header_when_name_null_throws_ArgumentNullException()
+    {
+        var builder = new MailMessageBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.Header(null!, "value")
+        );
+    }
+
+
+
+    [Fact]
+    public void Attach_filePath_when_null_throws_ArgumentNullException()
+    {
+        var builder = new MailMessageBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.Attach((string)null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void Attach_stream_when_content_null_throws_ArgumentNullException()
+    {
+        var builder = new MailMessageBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.Attach((System.IO.Stream)null!, "name")
+        );
+    }
+
+
+
+    [Fact]
+    public void Attach_stream_when_name_null_throws_ArgumentNullException()
+    {
+        var builder = new MailMessageBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.Attach(new System.IO.MemoryStream(), null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void Attach_bytes_when_content_null_throws_ArgumentNullException()
+    {
+        var builder = new MailMessageBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.Attach((byte[])null!, "name")
+        );
+    }
+
+
+
+    [Fact]
+    public void Attach_bytes_when_name_null_throws_ArgumentNullException()
+    {
+        var builder = new MailMessageBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.Attach(new byte[] { 1 }, null!)
+        );
+    }
+
+
+
+    // ---------- DeliveryNotification / Attach filePath ----------
+
+    [Fact]
+    public void Build_when_DeliveryNotification_set_applies_value()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .To("to@example.com")
+            .DeliveryNotification(DeliveryNotificationOptions.OnFailure)
+            .Build();
+
+        Assert.Equal(DeliveryNotificationOptions.OnFailure, msg.DeliveryNotificationOptions);
+    }
+
+
+
+    [Fact]
+    public void Attach_filePath_adds_attachment_from_file()
+    {
+        var filePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"test_{Guid.NewGuid():N}.txt");
+        System.IO.File.WriteAllText(filePath, "test content");
+
+        try
+        {
+            using var msg = new MailMessageBuilder()
+                .From("from@example.com")
+                .To("to@example.com")
+                .Attach(filePath)
+                .Build();
+
+            Assert.Single(msg.Attachments);
+        }
+        finally
+        {
+            if (System.IO.File.Exists(filePath))
+            {
+                System.IO.File.Delete(filePath);
+            }
+        }
+    }
 }

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/MailMessageBuilderTests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/MailMessageBuilderTests.cs
@@ -5,6 +5,8 @@ using System.Text;
 using Xunit;
 using Assert = Xunit.Assert;
 #pragma warning disable CA1707
+#pragma warning disable MA0074 // xUnit Assert.Contains triggers this for string overloads
+#pragma warning disable S3878 // Array creation is intentional to disambiguate To(IEnumerable) overload
 
 namespace Wolfgang.Extensions.Mail.Tests.Unit;
 
@@ -90,7 +92,7 @@ public class MailMessageBuilderTests
             .Cc("cc@example.com")
             .Build();
 
-        Assert.Equal(1, msg.CC.Count);
+        Assert.Single(msg.CC);
         Assert.Equal("cc@example.com", msg.CC[0].Address);
     }
 
@@ -105,7 +107,7 @@ public class MailMessageBuilderTests
             .Bcc("bcc@example.com")
             .Build();
 
-        Assert.Equal(1, msg.Bcc.Count);
+        Assert.Single(msg.Bcc);
     }
 
 
@@ -119,7 +121,7 @@ public class MailMessageBuilderTests
             .ReplyTo("reply@example.com")
             .Build();
 
-        Assert.Equal(1, msg.ReplyToList.Count);
+        Assert.Single(msg.ReplyToList);
     }
 
 
@@ -182,7 +184,7 @@ public class MailMessageBuilderTests
 
         Assert.Equal("Plain text", msg.Body);
         Assert.False(msg.IsBodyHtml);
-        Assert.Equal(1, msg.AlternateViews.Count);
+        Assert.Single(msg.AlternateViews);
         Assert.Contains("text/html", msg.AlternateViews[0].ContentType.MediaType);
     }
 
@@ -231,7 +233,7 @@ public class MailMessageBuilderTests
             .Attach(stream, "data.bin")
             .Build();
 
-        Assert.Equal(1, msg.Attachments.Count);
+        Assert.Single(msg.Attachments);
         Assert.Equal("data.bin", msg.Attachments[0].Name);
     }
 
@@ -246,7 +248,7 @@ public class MailMessageBuilderTests
             .Attach(new byte[] { 1, 2, 3 }, "report.pdf", "application/pdf")
             .Build();
 
-        Assert.Equal(1, msg.Attachments.Count);
+        Assert.Single(msg.Attachments);
         Assert.Equal("report.pdf", msg.Attachments[0].Name);
     }
 
@@ -307,15 +309,15 @@ public class MailMessageBuilderTests
             .Build();
 
         Assert.Equal("from@example.com", msg.From!.Address);
-        Assert.Equal(1, msg.To.Count);
-        Assert.Equal(1, msg.CC.Count);
-        Assert.Equal(1, msg.Bcc.Count);
-        Assert.Equal(1, msg.ReplyToList.Count);
+        Assert.Single(msg.To);
+        Assert.Single(msg.CC);
+        Assert.Single(msg.Bcc);
+        Assert.Single(msg.ReplyToList);
         Assert.Equal("Full Test", msg.Subject);
         Assert.Equal("Plain", msg.Body);
-        Assert.Equal(1, msg.AlternateViews.Count);
+        Assert.Single(msg.AlternateViews);
         Assert.Equal(MailPriority.High, msg.Priority);
         Assert.Equal("yes", msg.Headers["X-Test"]);
-        Assert.Equal(1, msg.Attachments.Count);
+        Assert.Single(msg.Attachments);
     }
 }

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/MailMessageBuilderTests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/MailMessageBuilderTests.cs
@@ -1,0 +1,321 @@
+using System;
+using System.IO;
+using System.Net.Mail;
+using System.Text;
+using Xunit;
+using Assert = Xunit.Assert;
+#pragma warning disable CA1707
+
+namespace Wolfgang.Extensions.Mail.Tests.Unit;
+
+public class MailMessageBuilderTests
+{
+    // ---------- Build validation ----------
+
+    [Fact]
+    public void Build_when_From_not_set_throws_InvalidOperationException()
+    {
+        var builder = new MailMessageBuilder();
+
+        Assert.Throws<InvalidOperationException>
+        (
+            () => builder.Build()
+        );
+    }
+
+
+
+    // ---------- From ----------
+
+    [Fact]
+    public void From_when_address_is_null_throws_ArgumentNullException()
+    {
+        var builder = new MailMessageBuilder();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => builder.From(null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void Build_when_From_set_creates_message_with_From()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("sender@example.com")
+            .To("to@example.com")
+            .Build();
+
+        Assert.Equal("sender@example.com", msg.From!.Address);
+    }
+
+
+
+    [Fact]
+    public void Build_when_From_has_display_name_preserves_it()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("sender@example.com", "Sender Name")
+            .To("to@example.com")
+            .Build();
+
+        Assert.Equal("Sender Name", msg.From!.DisplayName);
+    }
+
+
+
+    // ---------- Recipients ----------
+
+    [Fact]
+    public void Build_when_To_set_creates_message_with_recipients()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .To(new[] { "a@example.com", "b@example.com" })
+            .Build();
+
+        Assert.Equal(2, msg.To.Count);
+    }
+
+
+
+    [Fact]
+    public void Build_when_Cc_set_creates_message_with_CC()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .To("to@example.com")
+            .Cc("cc@example.com")
+            .Build();
+
+        Assert.Equal(1, msg.CC.Count);
+        Assert.Equal("cc@example.com", msg.CC[0].Address);
+    }
+
+
+
+    [Fact]
+    public void Build_when_Bcc_set_creates_message_with_BCC()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .To("to@example.com")
+            .Bcc("bcc@example.com")
+            .Build();
+
+        Assert.Equal(1, msg.Bcc.Count);
+    }
+
+
+
+    [Fact]
+    public void Build_when_ReplyTo_set_creates_message_with_ReplyToList()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .To("to@example.com")
+            .ReplyTo("reply@example.com")
+            .Build();
+
+        Assert.Equal(1, msg.ReplyToList.Count);
+    }
+
+
+
+    // ---------- Subject / Body ----------
+
+    [Fact]
+    public void Build_when_Subject_set_creates_message_with_subject()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .To("to@example.com")
+            .Subject("Test Subject")
+            .Build();
+
+        Assert.Equal("Test Subject", msg.Subject);
+    }
+
+
+
+    [Fact]
+    public void Build_when_PlainTextBody_only_sets_body_as_plain_text()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .To("to@example.com")
+            .PlainTextBody("Hello")
+            .Build();
+
+        Assert.Equal("Hello", msg.Body);
+        Assert.False(msg.IsBodyHtml);
+    }
+
+
+
+    [Fact]
+    public void Build_when_HtmlBody_only_sets_body_as_html()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .To("to@example.com")
+            .HtmlBody("<h1>Hello</h1>")
+            .Build();
+
+        Assert.Equal("<h1>Hello</h1>", msg.Body);
+        Assert.True(msg.IsBodyHtml);
+    }
+
+
+
+    [Fact]
+    public void Build_when_both_bodies_set_uses_plain_text_body_and_html_alternate_view()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .To("to@example.com")
+            .PlainTextBody("Plain text")
+            .HtmlBody("<h1>HTML</h1>")
+            .Build();
+
+        Assert.Equal("Plain text", msg.Body);
+        Assert.False(msg.IsBodyHtml);
+        Assert.Equal(1, msg.AlternateViews.Count);
+        Assert.Contains("text/html", msg.AlternateViews[0].ContentType.MediaType);
+    }
+
+
+
+    // ---------- Priority / Headers ----------
+
+    [Fact]
+    public void Build_when_Priority_set_applies_priority()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .To("to@example.com")
+            .Priority(MailPriority.High)
+            .Build();
+
+        Assert.Equal(MailPriority.High, msg.Priority);
+    }
+
+
+
+    [Fact]
+    public void Build_when_Header_set_applies_custom_header()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .To("to@example.com")
+            .Header("X-Custom", "value")
+            .Build();
+
+        Assert.Equal("value", msg.Headers["X-Custom"]);
+    }
+
+
+
+    // ---------- Attachments ----------
+
+    [Fact]
+    public void Build_when_Attach_stream_adds_attachment()
+    {
+        var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .To("to@example.com")
+            .Attach(stream, "data.bin")
+            .Build();
+
+        Assert.Equal(1, msg.Attachments.Count);
+        Assert.Equal("data.bin", msg.Attachments[0].Name);
+    }
+
+
+
+    [Fact]
+    public void Build_when_Attach_bytes_adds_attachment()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .To("to@example.com")
+            .Attach(new byte[] { 1, 2, 3 }, "report.pdf", "application/pdf")
+            .Build();
+
+        Assert.Equal(1, msg.Attachments.Count);
+        Assert.Equal("report.pdf", msg.Attachments[0].Name);
+    }
+
+
+
+    // ---------- Sender ----------
+
+    [Fact]
+    public void Build_when_SenderAddress_set_applies_sender()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .SenderAddress("actual@example.com", "Actual Sender")
+            .To("to@example.com")
+            .Build();
+
+        Assert.NotNull(msg.Sender);
+        Assert.Equal("actual@example.com", msg.Sender!.Address);
+    }
+
+
+
+    // ---------- Encoding ----------
+
+    [Fact]
+    public void Build_when_encodings_set_applies_encodings()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com")
+            .To("to@example.com")
+            .BodyEncoding(Encoding.UTF32)
+            .SubjectEncoding(Encoding.ASCII)
+            .Build();
+
+        Assert.Equal(Encoding.UTF32, msg.BodyEncoding);
+        Assert.Equal(Encoding.ASCII, msg.SubjectEncoding);
+    }
+
+
+
+    // ---------- Chaining ----------
+
+    [Fact]
+    public void Build_full_fluent_chain_produces_complete_message()
+    {
+        using var msg = new MailMessageBuilder()
+            .From("from@example.com", "From Name")
+            .To("to@example.com")
+            .Cc("cc@example.com")
+            .Bcc("bcc@example.com")
+            .ReplyTo("reply@example.com")
+            .Subject("Full Test")
+            .PlainTextBody("Plain")
+            .HtmlBody("<b>HTML</b>")
+            .Priority(MailPriority.High)
+            .Header("X-Test", "yes")
+            .Attach(new byte[] { 1 }, "file.bin")
+            .Build();
+
+        Assert.Equal("from@example.com", msg.From!.Address);
+        Assert.Equal(1, msg.To.Count);
+        Assert.Equal(1, msg.CC.Count);
+        Assert.Equal(1, msg.Bcc.Count);
+        Assert.Equal(1, msg.ReplyToList.Count);
+        Assert.Equal("Full Test", msg.Subject);
+        Assert.Equal("Plain", msg.Body);
+        Assert.Equal(1, msg.AlternateViews.Count);
+        Assert.Equal(MailPriority.High, msg.Priority);
+        Assert.Equal("yes", msg.Headers["X-Test"]);
+        Assert.Equal(1, msg.Attachments.Count);
+    }
+}


### PR DESCRIPTION
## Summary
- `MailMessageBuilder` — fluent builder for `MailMessage` construction
- Supports From, To, CC, BCC, ReplyTo, Subject, PlainTextBody, HtmlBody, Priority, Headers, Attachments (file, stream, bytes)
- When both HTML and plain text bodies are set, creates multipart/alternative with AlternateView
- Validates From is set at Build() time

Closes #22

## Test plan
- [x] 19 tests pass on net10.0
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)