### PR TITLE
Add EmlParser for parsing EML/MIME files into MailMessage

### DIFF
--- a/src/Wolfgang.Extensions.Mail/EmlParser.cs
+++ b/src/Wolfgang.Extensions.Mail/EmlParser.cs
@@ -25,6 +25,24 @@ namespace Wolfgang.Extensions.Mail;
 public static class EmlParser
 {
 
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+
+    private const RegexOptions DefaultRegexOptions =
+        RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture;
+
+    private const RegexOptions DefaultRegexOptionsNoCase =
+        RegexOptions.ExplicitCapture;
+
+    private static readonly HashSet<string> StandardHeaderNames =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "from", "to", "cc", "bcc", "reply-to", "subject",
+        "content-type", "content-transfer-encoding", "mime-version",
+        "date", "message-id"
+    };
+
+
+
     /// <summary>
     /// Parses a raw EML/MIME string into a <see cref="MailMessage"/>.
     /// </summary>
@@ -53,96 +71,11 @@ public static class EmlParser
         var headers = ParseHeaders(headerSection);
         var message = new MailMessage();
 
-        // From
-        if (headers.TryGetValue("from", out var from) && !string.IsNullOrWhiteSpace(from))
-        {
-            try { message.From = ParseMailAddressSafe(from); }
-            catch (FormatException) { /* Skip malformed From */ }
-        }
-
-        // To
-        if (headers.TryGetValue("to", out var to))
-        {
-            AddAddresses(message.To, to);
-        }
-
-        // CC
-        if (headers.TryGetValue("cc", out var cc))
-        {
-            AddAddresses(message.CC, cc);
-        }
-
-        // BCC
-        if (headers.TryGetValue("bcc", out var bcc))
-        {
-            AddAddresses(message.Bcc, bcc);
-        }
-
-        // Reply-To
-        if (headers.TryGetValue("reply-to", out var replyTo))
-        {
-            AddAddresses(message.ReplyToList, replyTo);
-        }
-
-        // Subject — decode RFC 2047 encoded words
-        if (headers.TryGetValue("subject", out var subject))
-        {
-            message.Subject = DecodeEncodedWords(subject);
-        }
-
-        // Content-Type
-        var contentType = headers.TryGetValue("content-type", out var ct) ? ct : "text/plain";
-        var isMultipart = contentType.IndexOf("multipart/", StringComparison.OrdinalIgnoreCase) >= 0;
-
-        // Content-Transfer-Encoding
-        var transferEncoding = headers.TryGetValue("content-transfer-encoding", out var cte)
-            ? cte.Trim().ToLowerInvariant()
-            : "7bit";
-
-        if (isMultipart)
-        {
-            var boundary = ExtractBoundary(contentType);
-            if (boundary != null)
-            {
-                ParseMultipart(message, bodySection, boundary);
-            }
-        }
-        else
-        {
-            // Simple single-part message
-            var isHtml = contentType.IndexOf("text/html", StringComparison.OrdinalIgnoreCase) >= 0;
-            message.IsBodyHtml = isHtml;
-            message.Body = DecodeBody(bodySection, transferEncoding);
-        }
-
-        // Custom headers (skip standard ones)
-        var standardHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "from", "to", "cc", "bcc", "reply-to", "subject",
-            "content-type", "content-transfer-encoding", "mime-version",
-            "date", "message-id"
-        };
-
-        foreach (var kvp in headers)
-        {
-            if (!standardHeaders.Contains(kvp.Key))
-            {
-                message.Headers[kvp.Key] = kvp.Value;
-            }
-        }
-
-        // Priority
-        if (headers.TryGetValue("x-priority", out var priority))
-        {
-            if (priority.Trim().StartsWith("1") || priority.Trim().StartsWith("2"))
-            {
-                message.Priority = MailPriority.High;
-            }
-            else if (priority.Trim().StartsWith("4") || priority.Trim().StartsWith("5"))
-            {
-                message.Priority = MailPriority.Low;
-            }
-        }
+        ApplyAddressHeaders(message, headers);
+        ApplySubject(message, headers);
+        ApplyBodyOrMultipart(message, headers, bodySection);
+        ApplyCustomHeaders(message, headers);
+        ApplyPriority(message, headers);
 
         return message;
     }
@@ -196,7 +129,9 @@ public static class EmlParser
 
 #if NETSTANDARD2_0 || NET462
         cancellationToken.ThrowIfCancellationRequested();
+#pragma warning disable RS0030
         var content = File.ReadAllText(filePath, Encoding.UTF8);
+#pragma warning restore RS0030
         await Task.CompletedTask.ConfigureAwait(false);
 #else
         var content = await File.ReadAllTextAsync(filePath, Encoding.UTF8, cancellationToken)
@@ -209,8 +144,134 @@ public static class EmlParser
 
 
     // ==========================================================================
-    // Private helpers
+    // Parse helpers
     // ==========================================================================
+
+    private static void ApplyAddressHeaders
+    (
+        MailMessage message,
+        Dictionary<string, string> headers
+    )
+    {
+        if (headers.TryGetValue("from", out var from) && !string.IsNullOrWhiteSpace(from))
+        {
+            try { message.From = ParseMailAddressSafe(from); }
+            catch (FormatException) { /* Skip malformed From */ }
+        }
+
+        if (headers.TryGetValue("to", out var to))
+        {
+            AddAddresses(message.To, to);
+        }
+
+        if (headers.TryGetValue("cc", out var cc))
+        {
+            AddAddresses(message.CC, cc);
+        }
+
+        if (headers.TryGetValue("bcc", out var bcc))
+        {
+            AddAddresses(message.Bcc, bcc);
+        }
+
+        if (headers.TryGetValue("reply-to", out var replyTo))
+        {
+            AddAddresses(message.ReplyToList, replyTo);
+        }
+    }
+
+
+
+    private static void ApplySubject
+    (
+        MailMessage message,
+        Dictionary<string, string> headers
+    )
+    {
+        if (headers.TryGetValue("subject", out var subject))
+        {
+            message.Subject = DecodeEncodedWords(subject);
+        }
+    }
+
+
+
+    private static void ApplyBodyOrMultipart
+    (
+        MailMessage message,
+        Dictionary<string, string> headers,
+        string bodySection
+    )
+    {
+        var contentType = headers.TryGetValue("content-type", out var ct) ? ct : "text/plain";
+        var isMultipart = contentType.IndexOf("multipart/", StringComparison.OrdinalIgnoreCase) >= 0;
+        var transferEncoding = headers.TryGetValue("content-transfer-encoding", out var cte)
+            ? cte.Trim().ToLowerInvariant()
+            : "7bit";
+
+        if (isMultipart)
+        {
+            var boundary = ExtractBoundary(contentType);
+            if (boundary != null)
+            {
+                ParseMultipart(message, bodySection, boundary);
+            }
+        }
+        else
+        {
+            var isHtml = contentType.IndexOf("text/html", StringComparison.OrdinalIgnoreCase) >= 0;
+            message.IsBodyHtml = isHtml;
+            message.Body = DecodeBody(bodySection, transferEncoding);
+        }
+    }
+
+
+
+    private static void ApplyCustomHeaders
+    (
+        MailMessage message,
+        Dictionary<string, string> headers
+    )
+    {
+        var customHeaders = headers.Where(kvp => !StandardHeaderNames.Contains(kvp.Key));
+
+        foreach (var kvp in customHeaders)
+        {
+            message.Headers[kvp.Key] = kvp.Value;
+        }
+    }
+
+
+
+    private static void ApplyPriority
+    (
+        MailMessage message,
+        Dictionary<string, string> headers
+    )
+    {
+        if (!headers.TryGetValue("x-priority", out var priority))
+        {
+            return;
+        }
+
+        var trimmed = priority.Trim();
+        if (trimmed.Length == 0)
+        {
+            return;
+        }
+
+        var firstChar = trimmed[0];
+        if (firstChar == '1' || firstChar == '2')
+        {
+            message.Priority = MailPriority.High;
+        }
+        else if (firstChar == '4' || firstChar == '5')
+        {
+            message.Priority = MailPriority.Low;
+        }
+    }
+
+
 
     private static int FindHeaderBodySeparator
     (
@@ -287,8 +348,14 @@ public static class EmlParser
         string contentType
     )
     {
-        var match = Regex.Match(contentType, @"boundary=""?([^"";\s]+)""?", RegexOptions.IgnoreCase);
-        return match.Success ? match.Groups[1].Value : null;
+        var match = Regex.Match
+        (
+            contentType,
+            @"boundary=""?(?<boundary>[^"";\s]+)""?",
+            DefaultRegexOptions,
+            RegexTimeout
+        );
+        return match.Success ? match.Groups["boundary"].Value : null;
     }
 
 
@@ -307,8 +374,7 @@ public static class EmlParser
         {
             var part = rawPart.Trim('\r', '\n');
 
-            // Skip empty parts and closing boundary
-            if (string.IsNullOrWhiteSpace(part) || part.StartsWith("--"))
+            if (string.IsNullOrWhiteSpace(part) || part.StartsWith("--", StringComparison.Ordinal))
             {
                 continue;
             }
@@ -324,69 +390,129 @@ public static class EmlParser
             var partTransferEncoding = partHeaders.TryGetValue("content-transfer-encoding", out var pcte)
                 ? pcte.Trim().ToLowerInvariant() : "7bit";
 
-            // Check for nested multipart
-            if (partContentType.IndexOf("multipart/", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (TryHandleNestedMultipart(message, partContentType, partBody))
             {
-                var nestedBoundary = ExtractBoundary(partContentType);
-                if (nestedBoundary != null)
-                {
-                    ParseMultipart(message, partBody, nestedBoundary);
-                }
                 continue;
             }
 
-            var isTextPlain = partContentType.IndexOf("text/plain", StringComparison.OrdinalIgnoreCase) >= 0;
-            var isTextHtml = partContentType.IndexOf("text/html", StringComparison.OrdinalIgnoreCase) >= 0;
+            ProcessSinglePart
+            (
+                message,
+                partHeaders,
+                partContentType,
+                partTransferEncoding,
+                partBody
+            );
+        }
+    }
 
-            var contentDisposition = partHeaders.TryGetValue("content-disposition", out var cd)
-                ? cd : null;
-            var isAttachment = contentDisposition != null &&
-                contentDisposition.IndexOf("attachment", StringComparison.OrdinalIgnoreCase) >= 0;
 
-            if (isAttachment || (!isTextPlain && !isTextHtml))
-            {
-                // Treat as attachment
-                var fileName = ExtractFileName(contentDisposition, partContentType) ?? "attachment.bin";
-                var attachmentBytes = DecodeBodyBytes(partBody, partTransferEncoding);
-                var stream = new MemoryStream(attachmentBytes, writable: false);
-                var mimeType = partContentType.Split(';')[0].Trim();
-                var attachment = new Attachment(stream, fileName, mimeType);
 
-                if (partHeaders.TryGetValue("content-id", out var cid))
-                {
-                    attachment.ContentId = cid.Trim('<', '>', ' ');
-                }
+    private static bool TryHandleNestedMultipart
+    (
+        MailMessage message,
+        string partContentType,
+        string partBody
+    )
+    {
+        if (partContentType.IndexOf("multipart/", StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            return false;
+        }
 
-                message.Attachments.Add(attachment);
-            }
-            else if (isTextHtml)
-            {
-                if (string.IsNullOrEmpty(message.Body))
-                {
-                    message.Body = DecodeBody(partBody, partTransferEncoding);
-                    message.IsBodyHtml = true;
-                }
-                else
-                {
-                    // Already have a body — add as alternate view
-                    var decodedHtml = DecodeBody(partBody, partTransferEncoding);
-                    var view = AlternateView.CreateAlternateViewFromString
-                    (
-                        decodedHtml,
-                        Encoding.UTF8,
-                        MediaTypeNames.Text.Html
-                    );
-                    message.AlternateViews.Add(view);
-                }
-            }
-            else if (isTextPlain)
-            {
-                if (string.IsNullOrEmpty(message.Body))
-                {
-                    message.Body = DecodeBody(partBody, partTransferEncoding);
-                    message.IsBodyHtml = false;
-                }
-            }
+        var nestedBoundary = ExtractBoundary(partContentType);
+        if (nestedBoundary != null)
+        {
+            ParseMultipart(message, partBody, nestedBoundary);
+        }
+
+        return true;
+    }
+
+
+
+    private static void ProcessSinglePart
+    (
+        MailMessage message,
+        Dictionary<string, string> partHeaders,
+        string partContentType,
+        string partTransferEncoding,
+        string partBody
+    )
+    {
+        var isTextPlain = partContentType.IndexOf("text/plain", StringComparison.OrdinalIgnoreCase) >= 0;
+        var isTextHtml = partContentType.IndexOf("text/html", StringComparison.OrdinalIgnoreCase) >= 0;
+
+        var contentDisposition = partHeaders.TryGetValue("content-disposition", out var cd)
+            ? cd : null;
+        var isAttachment = contentDisposition != null &&
+            contentDisposition.IndexOf("attachment", StringComparison.OrdinalIgnoreCase) >= 0;
+
+        if (isAttachment || (!isTextPlain && !isTextHtml))
+        {
+            AddAttachmentPart(message, partHeaders, partContentType, partTransferEncoding, partBody, contentDisposition);
+        }
+        else if (isTextHtml)
+        {
+            AddHtmlPart(message, partBody, partTransferEncoding);
+        }
+        else if (isTextPlain && string.IsNullOrEmpty(message.Body))
+        {
+            message.Body = DecodeBody(partBody, partTransferEncoding);
+            message.IsBodyHtml = false;
+        }
+    }
+
+
+
+    private static void AddAttachmentPart
+    (
+        MailMessage message,
+        Dictionary<string, string> partHeaders,
+        string partContentType,
+        string partTransferEncoding,
+        string partBody,
+        string? contentDisposition
+    )
+    {
+        var fileName = ExtractFileName(contentDisposition, partContentType) ?? "attachment.bin";
+        var attachmentBytes = DecodeBodyBytes(partBody, partTransferEncoding);
+        var stream = new MemoryStream(attachmentBytes, writable: false);
+        var mimeType = partContentType.Split(';')[0].Trim();
+        var attachment = new Attachment(stream, fileName, mimeType);
+
+        if (partHeaders.TryGetValue("content-id", out var cid))
+        {
+            attachment.ContentId = cid.Trim('<', '>', ' ');
+        }
+
+        message.Attachments.Add(attachment);
+    }
+
+
+
+    private static void AddHtmlPart
+    (
+        MailMessage message,
+        string partBody,
+        string partTransferEncoding
+    )
+    {
+        if (string.IsNullOrEmpty(message.Body))
+        {
+            message.Body = DecodeBody(partBody, partTransferEncoding);
+            message.IsBodyHtml = true;
+        }
+        else
+        {
+            var decodedHtml = DecodeBody(partBody, partTransferEncoding);
+            var view = AlternateView.CreateAlternateViewFromString
+            (
+                decodedHtml,
+                Encoding.UTF8,
+                MediaTypeNames.Text.Html
+            );
+            message.AlternateViews.Add(view);
         }
     }
 
@@ -400,12 +526,24 @@ public static class EmlParser
     {
         if (contentDisposition != null)
         {
-            var match = Regex.Match(contentDisposition, @"filename=""?([^"";\s]+)""?", RegexOptions.IgnoreCase);
-            if (match.Success) return match.Groups[1].Value;
+            var match = Regex.Match
+            (
+                contentDisposition,
+                @"filename=""?(?<filename>[^"";\s]+)""?",
+                DefaultRegexOptions,
+                RegexTimeout
+            );
+            if (match.Success) return match.Groups["filename"].Value;
         }
 
-        var nameMatch = Regex.Match(contentType, @"name=""?([^"";\s]+)""?", RegexOptions.IgnoreCase);
-        return nameMatch.Success ? nameMatch.Groups[1].Value : null;
+        var nameMatch = Regex.Match
+        (
+            contentType,
+            @"name=""?(?<name>[^"";\s]+)""?",
+            DefaultRegexOptions,
+            RegexTimeout
+        );
+        return nameMatch.Success ? nameMatch.Groups["name"].Value : null;
     }
 
 
@@ -421,7 +559,7 @@ public static class EmlParser
             case "base64":
                 try
                 {
-                    var cleaned = Regex.Replace(body, @"\s+", "");
+                    var cleaned = Regex.Replace(body, @"\s+", "", DefaultRegexOptionsNoCase, RegexTimeout);
                     var bytes = Convert.FromBase64String(cleaned);
                     return Encoding.UTF8.GetString(bytes);
                 }
@@ -451,7 +589,7 @@ public static class EmlParser
             case "base64":
                 try
                 {
-                    var cleaned = Regex.Replace(body, @"\s+", "");
+                    var cleaned = Regex.Replace(body, @"\s+", "", DefaultRegexOptionsNoCase, RegexTimeout);
                     return Convert.FromBase64String(cleaned);
                 }
                 catch (FormatException)
@@ -475,28 +613,30 @@ public static class EmlParser
     )
     {
         // Remove soft line breaks (= at end of line)
-        var cleaned = Regex.Replace(input, @"=\r?\n", "");
+        var cleaned = Regex.Replace(input, @"=\r?\n", "", DefaultRegexOptionsNoCase, RegexTimeout);
 
         // Collect bytes for proper multi-byte UTF-8 decoding
         var result = new List<byte>();
+        var i = 0;
 
-        for (var i = 0; i < cleaned.Length; i++)
+        while (i < cleaned.Length)
         {
             if (cleaned[i] == '=' && i + 2 < cleaned.Length
                 && IsHexChar(cleaned[i + 1]) && IsHexChar(cleaned[i + 2]))
             {
                 result.Add(Convert.ToByte(cleaned.Substring(i + 1, 2), 16));
-                i += 2;
+                i += 3;
             }
             else
             {
-                // Flush any pending bytes, then add the literal char
                 var ch = cleaned[i];
                 var charBytes = Encoding.UTF8.GetBytes(new[] { ch });
                 foreach (var b in charBytes)
                 {
                     result.Add(b);
                 }
+
+                i++;
             }
         }
 
@@ -524,53 +664,74 @@ public static class EmlParser
         return Regex.Replace
         (
             input,
-            @"=\?([^?]+)\?([BbQq])\?([^?]+)\?=",
-            m =>
-            {
-                var charset = m.Groups[1].Value;
-                var encoding = m.Groups[2].Value.ToUpperInvariant();
-                var encodedText = m.Groups[3].Value;
-
-                try
-                {
-                    var enc = Encoding.GetEncoding(charset);
-
-                    if (encoding == "B")
-                    {
-                        var bytes = Convert.FromBase64String(encodedText);
-                        return enc.GetString(bytes);
-                    }
-                    else // Q encoding — collect bytes for proper multi-byte decoding
-                    {
-                        var qText = encodedText.Replace('_', ' ');
-                        var byteList = new List<byte>();
-
-                        for (var i = 0; i < qText.Length; i++)
-                        {
-                            if (qText[i] == '=' && i + 2 < qText.Length
-                                && IsHexChar(qText[i + 1]) && IsHexChar(qText[i + 2]))
-                            {
-                                byteList.Add(Convert.ToByte(qText.Substring(i + 1, 2), 16));
-                                i += 2;
-                            }
-                            else
-                            {
-                                foreach (var b in enc.GetBytes(new[] { qText[i] }))
-                                {
-                                    byteList.Add(b);
-                                }
-                            }
-                        }
-
-                        return enc.GetString(byteList.ToArray());
-                    }
-                }
-                catch
-                {
-                    return m.Value;
-                }
-            }
+            @"=\?(?<charset>[^?]+)\?(?<encoding>[BbQq])\?(?<text>[^?]+)\?=",
+            DecodeEncodedWordMatch,
+            DefaultRegexOptionsNoCase,
+            RegexTimeout
         );
+    }
+
+
+
+    private static string DecodeEncodedWordMatch
+    (
+        Match m
+    )
+    {
+        var charset = m.Groups["charset"].Value;
+        var encoding = m.Groups["encoding"].Value.ToUpperInvariant();
+        var encodedText = m.Groups["text"].Value;
+
+        try
+        {
+            var enc = Encoding.GetEncoding(charset);
+
+            if (string.Equals(encoding, "B", StringComparison.Ordinal))
+            {
+                var bytes = Convert.FromBase64String(encodedText);
+                return enc.GetString(bytes);
+            }
+
+            return DecodeQEncoding(encodedText, enc);
+        }
+        catch (Exception ex) when (ex is FormatException || ex is ArgumentException)
+        {
+            return m.Value;
+        }
+    }
+
+
+
+    private static string DecodeQEncoding
+    (
+        string encodedText,
+        Encoding enc
+    )
+    {
+        var qText = encodedText.Replace('_', ' ');
+        var byteList = new List<byte>();
+        var i = 0;
+
+        while (i < qText.Length)
+        {
+            if (qText[i] == '=' && i + 2 < qText.Length
+                && IsHexChar(qText[i + 1]) && IsHexChar(qText[i + 2]))
+            {
+                byteList.Add(Convert.ToByte(qText.Substring(i + 1, 2), 16));
+                i += 3;
+            }
+            else
+            {
+                foreach (var b in enc.GetBytes(new[] { qText[i] }))
+                {
+                    byteList.Add(b);
+                }
+
+                i++;
+            }
+        }
+
+        return enc.GetString(byteList.ToArray());
     }
 
 
@@ -580,21 +741,35 @@ public static class EmlParser
         string addressString
     )
     {
+        var trimmed = addressString.Trim();
+
         // Handle "Display Name" <email@example.com> format
-        var match = Regex.Match(addressString.Trim(), @"^""?([^""<]+?)""?\s*<([^>]+)>$");
+        var match = Regex.Match
+        (
+            trimmed,
+            @"^""?(?<name>[^""<]+?)""?\s*<(?<email>[^>]+)>$",
+            DefaultRegexOptionsNoCase,
+            RegexTimeout
+        );
         if (match.Success)
         {
-            return new MailAddress(match.Groups[2].Value.Trim(), match.Groups[1].Value.Trim());
+            return new MailAddress(match.Groups["email"].Value.Trim(), match.Groups["name"].Value.Trim());
         }
 
         // Handle bare <email@example.com>
-        var angleBracket = Regex.Match(addressString.Trim(), @"^<([^>]+)>$");
+        var angleBracket = Regex.Match
+        (
+            trimmed,
+            @"^<(?<email>[^>]+)>$",
+            DefaultRegexOptionsNoCase,
+            RegexTimeout
+        );
         if (angleBracket.Success)
         {
-            return new MailAddress(angleBracket.Groups[1].Value.Trim());
+            return new MailAddress(angleBracket.Groups["email"].Value.Trim());
         }
 
-        return new MailAddress(addressString.Trim());
+        return new MailAddress(trimmed);
     }
 
 

--- a/src/Wolfgang.Extensions.Mail/EmlParser.cs
+++ b/src/Wolfgang.Extensions.Mail/EmlParser.cs
@@ -349,7 +349,8 @@ public static class EmlParser
                 var fileName = ExtractFileName(contentDisposition, partContentType) ?? "attachment.bin";
                 var attachmentBytes = DecodeBodyBytes(partBody, partTransferEncoding);
                 var stream = new MemoryStream(attachmentBytes, writable: false);
-                var attachment = new Attachment(stream, fileName);
+                var mimeType = partContentType.Split(';')[0].Trim();
+                var attachment = new Attachment(stream, fileName, mimeType);
 
                 if (partHeaders.TryGetValue("content-id", out var cid))
                 {
@@ -539,17 +540,29 @@ public static class EmlParser
                         var bytes = Convert.FromBase64String(encodedText);
                         return enc.GetString(bytes);
                     }
-                    else // Q encoding
+                    else // Q encoding — collect bytes for proper multi-byte decoding
                     {
-                        var decoded = encodedText
-                            .Replace('_', ' ');
-                        decoded = Regex.Replace
-                        (
-                            decoded,
-                            @"=([0-9A-Fa-f]{2})",
-                            hex => ((char)Convert.ToByte(hex.Groups[1].Value, 16)).ToString()
-                        );
-                        return decoded;
+                        var qText = encodedText.Replace('_', ' ');
+                        var byteList = new List<byte>();
+
+                        for (var i = 0; i < qText.Length; i++)
+                        {
+                            if (qText[i] == '=' && i + 2 < qText.Length
+                                && IsHexChar(qText[i + 1]) && IsHexChar(qText[i + 2]))
+                            {
+                                byteList.Add(Convert.ToByte(qText.Substring(i + 1, 2), 16));
+                                i += 2;
+                            }
+                            else
+                            {
+                                foreach (var b in enc.GetBytes(new[] { qText[i] }))
+                                {
+                                    byteList.Add(b);
+                                }
+                            }
+                        }
+
+                        return enc.GetString(byteList.ToArray());
                     }
                 }
                 catch

--- a/src/Wolfgang.Extensions.Mail/EmlParser.cs
+++ b/src/Wolfgang.Extensions.Mail/EmlParser.cs
@@ -1,0 +1,661 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Mail;
+using System.Net.Mime;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Wolfgang.Extensions.Mail;
+
+
+/// <summary>
+/// Provides methods to parse EML (RFC 2822 MIME) content into <see cref="MailMessage"/> objects.
+/// </summary>
+/// <example>
+/// <code>
+/// using var message = EmlParser.Parse(File.ReadAllText("message.eml"));
+/// Console.WriteLine(message.Subject);
+/// </code>
+/// </example>
+// ReSharper disable once UnusedType.Global
+public static class EmlParser
+{
+
+    /// <summary>
+    /// Parses a raw EML/MIME string into a <see cref="MailMessage"/>.
+    /// </summary>
+    /// <param name="emlContent">The EML content string.</param>
+    /// <returns>A new <see cref="MailMessage"/> populated from the EML content.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="emlContent"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public static MailMessage Parse
+    (
+        string emlContent
+    )
+    {
+        if (emlContent == null)
+        {
+            throw new ArgumentNullException(nameof(emlContent));
+        }
+
+        var headerEndIndex = FindHeaderBodySeparator(emlContent);
+        var headerSection = headerEndIndex >= 0
+            ? emlContent.Substring(0, headerEndIndex)
+            : emlContent;
+        var bodySection = headerEndIndex >= 0
+            ? emlContent.Substring(headerEndIndex).TrimStart('\r', '\n')
+            : string.Empty;
+
+        var headers = ParseHeaders(headerSection);
+        var message = new MailMessage();
+
+        // From
+        if (headers.TryGetValue("from", out var from) && !string.IsNullOrWhiteSpace(from))
+        {
+            try { message.From = ParseMailAddressSafe(from); }
+            catch (FormatException) { /* Skip malformed From */ }
+        }
+
+        // To
+        if (headers.TryGetValue("to", out var to))
+        {
+            AddAddresses(message.To, to);
+        }
+
+        // CC
+        if (headers.TryGetValue("cc", out var cc))
+        {
+            AddAddresses(message.CC, cc);
+        }
+
+        // BCC
+        if (headers.TryGetValue("bcc", out var bcc))
+        {
+            AddAddresses(message.Bcc, bcc);
+        }
+
+        // Reply-To
+        if (headers.TryGetValue("reply-to", out var replyTo))
+        {
+            AddAddresses(message.ReplyToList, replyTo);
+        }
+
+        // Subject — decode RFC 2047 encoded words
+        if (headers.TryGetValue("subject", out var subject))
+        {
+            message.Subject = DecodeEncodedWords(subject);
+        }
+
+        // Content-Type
+        var contentType = headers.TryGetValue("content-type", out var ct) ? ct : "text/plain";
+        var isMultipart = contentType.IndexOf("multipart/", StringComparison.OrdinalIgnoreCase) >= 0;
+
+        // Content-Transfer-Encoding
+        var transferEncoding = headers.TryGetValue("content-transfer-encoding", out var cte)
+            ? cte.Trim().ToLowerInvariant()
+            : "7bit";
+
+        if (isMultipart)
+        {
+            var boundary = ExtractBoundary(contentType);
+            if (boundary != null)
+            {
+                ParseMultipart(message, bodySection, boundary);
+            }
+        }
+        else
+        {
+            // Simple single-part message
+            var isHtml = contentType.IndexOf("text/html", StringComparison.OrdinalIgnoreCase) >= 0;
+            message.IsBodyHtml = isHtml;
+            message.Body = DecodeBody(bodySection, transferEncoding);
+        }
+
+        // Custom headers (skip standard ones)
+        var standardHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "from", "to", "cc", "bcc", "reply-to", "subject",
+            "content-type", "content-transfer-encoding", "mime-version",
+            "date", "message-id"
+        };
+
+        foreach (var kvp in headers)
+        {
+            if (!standardHeaders.Contains(kvp.Key))
+            {
+                message.Headers[kvp.Key] = kvp.Value;
+            }
+        }
+
+        // Priority
+        if (headers.TryGetValue("x-priority", out var priority))
+        {
+            if (priority.Trim().StartsWith("1") || priority.Trim().StartsWith("2"))
+            {
+                message.Priority = MailPriority.High;
+            }
+            else if (priority.Trim().StartsWith("4") || priority.Trim().StartsWith("5"))
+            {
+                message.Priority = MailPriority.Low;
+            }
+        }
+
+        return message;
+    }
+
+
+
+    /// <summary>
+    /// Parses an EML file into a <see cref="MailMessage"/>.
+    /// </summary>
+    /// <param name="filePath">The path to the EML file.</param>
+    /// <returns>A new <see cref="MailMessage"/> populated from the file.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="filePath"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public static MailMessage ParseFile
+    (
+        string filePath
+    )
+    {
+        if (filePath == null)
+        {
+            throw new ArgumentNullException(nameof(filePath));
+        }
+
+#pragma warning disable RS0030 // File I/O - reading EML file
+        var content = File.ReadAllText(filePath, Encoding.UTF8);
+#pragma warning restore RS0030
+
+        return Parse(content);
+    }
+
+
+
+    /// <summary>
+    /// Asynchronously parses an EML file into a <see cref="MailMessage"/>.
+    /// </summary>
+    /// <param name="filePath">The path to the EML file.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task containing the parsed <see cref="MailMessage"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="filePath"/> is null.</exception>
+    // ReSharper disable once UnusedMember.Global
+    public static async Task<MailMessage> ParseFileAsync
+    (
+        string filePath,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (filePath == null)
+        {
+            throw new ArgumentNullException(nameof(filePath));
+        }
+
+#if NETSTANDARD2_0 || NET462
+        cancellationToken.ThrowIfCancellationRequested();
+        var content = File.ReadAllText(filePath, Encoding.UTF8);
+        await Task.CompletedTask.ConfigureAwait(false);
+#else
+        var content = await File.ReadAllTextAsync(filePath, Encoding.UTF8, cancellationToken)
+            .ConfigureAwait(false);
+#endif
+
+        return Parse(content);
+    }
+
+
+
+    // ==========================================================================
+    // Private helpers
+    // ==========================================================================
+
+    private static int FindHeaderBodySeparator
+    (
+        string content
+    )
+    {
+        // Headers and body are separated by a blank line (\r\n\r\n or \n\n)
+        var idx = content.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+        if (idx >= 0) return idx + 4;
+
+        idx = content.IndexOf("\n\n", StringComparison.Ordinal);
+        if (idx >= 0) return idx + 2;
+
+        return -1;
+    }
+
+
+
+    private static Dictionary<string, string> ParseHeaders
+    (
+        string headerSection
+    )
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        string? currentKey = null;
+        var currentValue = new StringBuilder();
+
+        foreach (var rawLine in headerSection.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None))
+        {
+            if (rawLine.Length > 0 && (rawLine[0] == ' ' || rawLine[0] == '\t'))
+            {
+                // Continuation of previous header (folded)
+                if (currentKey != null)
+                {
+                    currentValue.Append(' ');
+                    currentValue.Append(rawLine.Trim());
+                }
+            }
+            else
+            {
+                // Save previous header
+                if (currentKey != null)
+                {
+                    headers[currentKey] = currentValue.ToString();
+                }
+
+                // Parse new header
+                var colonIndex = rawLine.IndexOf(':');
+                if (colonIndex > 0)
+                {
+                    currentKey = rawLine.Substring(0, colonIndex).Trim();
+                    currentValue = new StringBuilder(rawLine.Substring(colonIndex + 1).Trim());
+                }
+                else
+                {
+                    currentKey = null;
+                }
+            }
+        }
+
+        // Save last header
+        if (currentKey != null)
+        {
+            headers[currentKey] = currentValue.ToString();
+        }
+
+        return headers;
+    }
+
+
+
+    private static string? ExtractBoundary
+    (
+        string contentType
+    )
+    {
+        var match = Regex.Match(contentType, @"boundary=""?([^"";\s]+)""?", RegexOptions.IgnoreCase);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+
+
+    private static void ParseMultipart
+    (
+        MailMessage message,
+        string body,
+        string boundary
+    )
+    {
+        var delimiter = "--" + boundary;
+        var parts = body.Split(new[] { delimiter }, StringSplitOptions.None);
+
+        foreach (var rawPart in parts)
+        {
+            var part = rawPart.Trim('\r', '\n');
+
+            // Skip empty parts and closing boundary
+            if (string.IsNullOrWhiteSpace(part) || part.StartsWith("--"))
+            {
+                continue;
+            }
+
+            var partHeaderEnd = FindHeaderBodySeparator(part);
+            if (partHeaderEnd < 0) continue;
+
+            var partHeaders = ParseHeaders(part.Substring(0, partHeaderEnd));
+            var partBody = part.Substring(partHeaderEnd).TrimStart('\r', '\n');
+
+            var partContentType = partHeaders.TryGetValue("content-type", out var pct)
+                ? pct : "text/plain";
+            var partTransferEncoding = partHeaders.TryGetValue("content-transfer-encoding", out var pcte)
+                ? pcte.Trim().ToLowerInvariant() : "7bit";
+
+            // Check for nested multipart
+            if (partContentType.IndexOf("multipart/", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                var nestedBoundary = ExtractBoundary(partContentType);
+                if (nestedBoundary != null)
+                {
+                    ParseMultipart(message, partBody, nestedBoundary);
+                }
+                continue;
+            }
+
+            var isTextPlain = partContentType.IndexOf("text/plain", StringComparison.OrdinalIgnoreCase) >= 0;
+            var isTextHtml = partContentType.IndexOf("text/html", StringComparison.OrdinalIgnoreCase) >= 0;
+
+            var contentDisposition = partHeaders.TryGetValue("content-disposition", out var cd)
+                ? cd : null;
+            var isAttachment = contentDisposition != null &&
+                contentDisposition.IndexOf("attachment", StringComparison.OrdinalIgnoreCase) >= 0;
+
+            if (isAttachment || (!isTextPlain && !isTextHtml))
+            {
+                // Treat as attachment
+                var fileName = ExtractFileName(contentDisposition, partContentType) ?? "attachment.bin";
+                var attachmentBytes = DecodeBodyBytes(partBody, partTransferEncoding);
+                var stream = new MemoryStream(attachmentBytes, writable: false);
+                var attachment = new Attachment(stream, fileName);
+
+                if (partHeaders.TryGetValue("content-id", out var cid))
+                {
+                    attachment.ContentId = cid.Trim('<', '>', ' ');
+                }
+
+                message.Attachments.Add(attachment);
+            }
+            else if (isTextHtml)
+            {
+                if (string.IsNullOrEmpty(message.Body))
+                {
+                    message.Body = DecodeBody(partBody, partTransferEncoding);
+                    message.IsBodyHtml = true;
+                }
+                else
+                {
+                    // Already have a body — add as alternate view
+                    var decodedHtml = DecodeBody(partBody, partTransferEncoding);
+                    var view = AlternateView.CreateAlternateViewFromString
+                    (
+                        decodedHtml,
+                        Encoding.UTF8,
+                        MediaTypeNames.Text.Html
+                    );
+                    message.AlternateViews.Add(view);
+                }
+            }
+            else if (isTextPlain)
+            {
+                if (string.IsNullOrEmpty(message.Body))
+                {
+                    message.Body = DecodeBody(partBody, partTransferEncoding);
+                    message.IsBodyHtml = false;
+                }
+            }
+        }
+    }
+
+
+
+    private static string? ExtractFileName
+    (
+        string? contentDisposition,
+        string contentType
+    )
+    {
+        if (contentDisposition != null)
+        {
+            var match = Regex.Match(contentDisposition, @"filename=""?([^"";\s]+)""?", RegexOptions.IgnoreCase);
+            if (match.Success) return match.Groups[1].Value;
+        }
+
+        var nameMatch = Regex.Match(contentType, @"name=""?([^"";\s]+)""?", RegexOptions.IgnoreCase);
+        return nameMatch.Success ? nameMatch.Groups[1].Value : null;
+    }
+
+
+
+    private static string DecodeBody
+    (
+        string body,
+        string transferEncoding
+    )
+    {
+        switch (transferEncoding)
+        {
+            case "base64":
+                try
+                {
+                    var cleaned = Regex.Replace(body, @"\s+", "");
+                    var bytes = Convert.FromBase64String(cleaned);
+                    return Encoding.UTF8.GetString(bytes);
+                }
+                catch (FormatException)
+                {
+                    return body;
+                }
+
+            case "quoted-printable":
+                return DecodeQuotedPrintable(body);
+
+            default:
+                return body;
+        }
+    }
+
+
+
+    private static byte[] DecodeBodyBytes
+    (
+        string body,
+        string transferEncoding
+    )
+    {
+        switch (transferEncoding)
+        {
+            case "base64":
+                try
+                {
+                    var cleaned = Regex.Replace(body, @"\s+", "");
+                    return Convert.FromBase64String(cleaned);
+                }
+                catch (FormatException)
+                {
+                    return Encoding.UTF8.GetBytes(body);
+                }
+
+            case "quoted-printable":
+                return Encoding.UTF8.GetBytes(DecodeQuotedPrintable(body));
+
+            default:
+                return Encoding.UTF8.GetBytes(body);
+        }
+    }
+
+
+
+    private static string DecodeQuotedPrintable
+    (
+        string input
+    )
+    {
+        // Remove soft line breaks (= at end of line)
+        var cleaned = Regex.Replace(input, @"=\r?\n", "");
+
+        // Collect bytes for proper multi-byte UTF-8 decoding
+        var result = new List<byte>();
+
+        for (var i = 0; i < cleaned.Length; i++)
+        {
+            if (cleaned[i] == '=' && i + 2 < cleaned.Length
+                && IsHexChar(cleaned[i + 1]) && IsHexChar(cleaned[i + 2]))
+            {
+                result.Add(Convert.ToByte(cleaned.Substring(i + 1, 2), 16));
+                i += 2;
+            }
+            else
+            {
+                // Flush any pending bytes, then add the literal char
+                var ch = cleaned[i];
+                var charBytes = Encoding.UTF8.GetBytes(new[] { ch });
+                foreach (var b in charBytes)
+                {
+                    result.Add(b);
+                }
+            }
+        }
+
+        return Encoding.UTF8.GetString(result.ToArray());
+    }
+
+
+
+    private static bool IsHexChar
+    (
+        char c
+    )
+    {
+        return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+    }
+
+
+
+    private static string DecodeEncodedWords
+    (
+        string input
+    )
+    {
+        // RFC 2047: =?charset?encoding?encoded-text?=
+        return Regex.Replace
+        (
+            input,
+            @"=\?([^?]+)\?([BbQq])\?([^?]+)\?=",
+            m =>
+            {
+                var charset = m.Groups[1].Value;
+                var encoding = m.Groups[2].Value.ToUpperInvariant();
+                var encodedText = m.Groups[3].Value;
+
+                try
+                {
+                    var enc = Encoding.GetEncoding(charset);
+
+                    if (encoding == "B")
+                    {
+                        var bytes = Convert.FromBase64String(encodedText);
+                        return enc.GetString(bytes);
+                    }
+                    else // Q encoding
+                    {
+                        var decoded = encodedText
+                            .Replace('_', ' ');
+                        decoded = Regex.Replace
+                        (
+                            decoded,
+                            @"=([0-9A-Fa-f]{2})",
+                            hex => ((char)Convert.ToByte(hex.Groups[1].Value, 16)).ToString()
+                        );
+                        return decoded;
+                    }
+                }
+                catch
+                {
+                    return m.Value;
+                }
+            }
+        );
+    }
+
+
+
+    private static MailAddress ParseMailAddressSafe
+    (
+        string addressString
+    )
+    {
+        // Handle "Display Name" <email@example.com> format
+        var match = Regex.Match(addressString.Trim(), @"^""?([^""<]+?)""?\s*<([^>]+)>$");
+        if (match.Success)
+        {
+            return new MailAddress(match.Groups[2].Value.Trim(), match.Groups[1].Value.Trim());
+        }
+
+        // Handle bare <email@example.com>
+        var angleBracket = Regex.Match(addressString.Trim(), @"^<([^>]+)>$");
+        if (angleBracket.Success)
+        {
+            return new MailAddress(angleBracket.Groups[1].Value.Trim());
+        }
+
+        return new MailAddress(addressString.Trim());
+    }
+
+
+
+    private static void AddAddresses
+    (
+        MailAddressCollection collection,
+        string addressList
+    )
+    {
+        // Split on comma, handling quoted display names
+        var addresses = SplitAddresses(addressList);
+
+        foreach (var addr in addresses)
+        {
+            var trimmed = addr.Trim();
+            if (string.IsNullOrWhiteSpace(trimmed)) continue;
+
+            try
+            {
+                collection.Add(ParseMailAddressSafe(trimmed));
+            }
+            catch (FormatException)
+            {
+                // Skip malformed addresses
+            }
+        }
+    }
+
+
+
+    private static IEnumerable<string> SplitAddresses
+    (
+        string addressList
+    )
+    {
+        var result = new List<string>();
+        var current = new StringBuilder();
+        var inQuotes = false;
+        var inAngleBrackets = false;
+
+        foreach (var ch in addressList)
+        {
+            if (ch == '"')
+            {
+                inQuotes = !inQuotes;
+                current.Append(ch);
+            }
+            else if (ch == '<' && !inQuotes)
+            {
+                inAngleBrackets = true;
+                current.Append(ch);
+            }
+            else if (ch == '>' && !inQuotes)
+            {
+                inAngleBrackets = false;
+                current.Append(ch);
+            }
+            else if (ch == ',' && !inQuotes && !inAngleBrackets)
+            {
+                result.Add(current.ToString());
+                current.Clear();
+            }
+            else
+            {
+                current.Append(ch);
+            }
+        }
+
+        if (current.Length > 0)
+        {
+            result.Add(current.ToString());
+        }
+
+        return result;
+    }
+}

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/EmlParserTests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/EmlParserTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Xunit;
 using Assert = Xunit.Assert;
 #pragma warning disable CA1707
+#pragma warning disable MA0074 // xUnit Assert.Contains triggers this for string overloads
 
 namespace Wolfgang.Extensions.Mail.Tests.Unit;
 
@@ -68,7 +69,7 @@ public class EmlParserTests
         using var msg = EmlParser.Parse(eml);
 
         Assert.Equal("sender@example.com", msg.From!.Address);
-        Assert.Equal(1, msg.To.Count);
+        Assert.Single(msg.To);
         Assert.Equal("recipient@example.com", msg.To[0].Address);
         Assert.Equal("Test Subject", msg.Subject);
         Assert.Equal("Hello, World!", msg.Body);
@@ -152,8 +153,8 @@ public class EmlParserTests
 
         using var msg = EmlParser.Parse(eml);
 
-        Assert.Equal(1, msg.CC.Count);
-        Assert.Equal(1, msg.Bcc.Count);
+        Assert.Single(msg.CC);
+        Assert.Single(msg.Bcc);
     }
 
 
@@ -274,7 +275,7 @@ public class EmlParserTests
         using var msg = EmlParser.Parse(eml);
 
         Assert.Equal("Plain text body", msg.Body);
-        Assert.Equal(1, msg.Attachments.Count);
+        Assert.Single(msg.Attachments);
         Assert.Equal("data.bin", msg.Attachments[0].Name);
     }
 
@@ -335,7 +336,7 @@ public class EmlParserTests
         using var parsed = EmlParser.Parse(eml);
 
         Assert.Equal("from@example.com", parsed.From!.Address);
-        Assert.Contains(parsed.To, a => a.Address == "to@example.com");
+        Assert.Contains(parsed.To, a => string.Equals(a.Address, "to@example.com", StringComparison.Ordinal));
         Assert.Equal("Round Trip", parsed.Subject);
         Assert.Contains("Test body", parsed.Body);
     }
@@ -389,7 +390,12 @@ public class EmlParserTests
 
         try
         {
+#if NETSTANDARD2_0 || NETFRAMEWORK
             File.WriteAllText(filePath, eml);
+            await Task.CompletedTask;
+#else
+            await File.WriteAllTextAsync(filePath, eml);
+#endif
             using var msg = await EmlParser.ParseFileAsync(filePath);
 
             Assert.Equal("Async File Test", msg.Subject);

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/EmlParserTests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/EmlParserTests.cs
@@ -180,6 +180,26 @@ public class EmlParserTests
 
 
 
+    [Fact]
+    public void Parse_when_subject_is_q_encoded_decodes_it()
+    {
+        // "Héllo" in UTF-8 Q-encoding: H=C3=A9llo
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: to@example.com",
+            "Subject: =?UTF-8?Q?H=C3=A9llo?=",
+            "",
+            "Body"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Equal("Héllo", msg.Subject);
+    }
+
+
+
     // ---------- Base64 body ----------
 
     [Fact]

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/EmlParserTests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/EmlParserTests.cs
@@ -1,0 +1,394 @@
+using System;
+using System.IO;
+using System.Net.Mail;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Assert = Xunit.Assert;
+#pragma warning disable CA1707
+
+namespace Wolfgang.Extensions.Mail.Tests.Unit;
+
+public class EmlParserTests
+{
+    // ---------- Null guards ----------
+
+    [Fact]
+    public void Parse_when_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => EmlParser.Parse(null!)
+        );
+        Assert.Equal("emlContent", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public void ParseFile_when_null_throws_ArgumentNullException()
+    {
+        var ex = Assert.Throws<ArgumentNullException>
+        (
+            () => EmlParser.ParseFile(null!)
+        );
+        Assert.Equal("filePath", ex.ParamName);
+    }
+
+
+
+    [Fact]
+    public async Task ParseFileAsync_when_null_throws_ArgumentNullException()
+    {
+        var ex = await Assert.ThrowsAsync<ArgumentNullException>
+        (
+            () => EmlParser.ParseFileAsync(null!)
+        );
+        Assert.Equal("filePath", ex.ParamName);
+    }
+
+
+
+    // ---------- Basic parsing ----------
+
+    [Fact]
+    public void Parse_when_simple_text_message_extracts_headers_and_body()
+    {
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: recipient@example.com",
+            "Subject: Test Subject",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain",
+            "",
+            "Hello, World!"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Equal("sender@example.com", msg.From!.Address);
+        Assert.Equal(1, msg.To.Count);
+        Assert.Equal("recipient@example.com", msg.To[0].Address);
+        Assert.Equal("Test Subject", msg.Subject);
+        Assert.Equal("Hello, World!", msg.Body);
+        Assert.False(msg.IsBodyHtml);
+    }
+
+
+
+    [Fact]
+    public void Parse_when_html_message_sets_IsBodyHtml()
+    {
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: recipient@example.com",
+            "Subject: HTML Test",
+            "Content-Type: text/html",
+            "",
+            "<h1>Hello</h1>"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.True(msg.IsBodyHtml);
+        Assert.Contains("<h1>Hello</h1>", msg.Body);
+    }
+
+
+
+    // ---------- Address parsing ----------
+
+    [Fact]
+    public void Parse_when_display_name_in_From_extracts_name_and_address()
+    {
+        var eml = BuildEml
+        (
+            "From: \"John Doe\" <john@example.com>",
+            "To: recipient@example.com",
+            "",
+            "Body"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Equal("john@example.com", msg.From!.Address);
+        Assert.Equal("John Doe", msg.From.DisplayName);
+    }
+
+
+
+    [Fact]
+    public void Parse_when_multiple_To_addresses_parses_all()
+    {
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: a@example.com, b@example.com, c@example.com",
+            "",
+            "Body"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Equal(3, msg.To.Count);
+    }
+
+
+
+    [Fact]
+    public void Parse_when_CC_and_BCC_present_parses_both()
+    {
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: to@example.com",
+            "CC: cc@example.com",
+            "BCC: bcc@example.com",
+            "",
+            "Body"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Equal(1, msg.CC.Count);
+        Assert.Equal(1, msg.Bcc.Count);
+    }
+
+
+
+    // ---------- Encoded subjects ----------
+
+    [Fact]
+    public void Parse_when_subject_is_base64_encoded_decodes_it()
+    {
+        var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes("Héllo Wörld"));
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: to@example.com",
+            $"Subject: =?UTF-8?B?{encoded}?=",
+            "",
+            "Body"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Equal("Héllo Wörld", msg.Subject);
+    }
+
+
+
+    // ---------- Base64 body ----------
+
+    [Fact]
+    public void Parse_when_body_is_base64_encoded_decodes_it()
+    {
+        var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes("Decoded content"));
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: to@example.com",
+            "Content-Type: text/plain",
+            "Content-Transfer-Encoding: base64",
+            "",
+            encoded
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Equal("Decoded content", msg.Body);
+    }
+
+
+
+    // ---------- Quoted-printable ----------
+
+    [Fact]
+    public void Parse_when_body_is_quoted_printable_decodes_it()
+    {
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: to@example.com",
+            "Content-Type: text/plain",
+            "Content-Transfer-Encoding: quoted-printable",
+            "",
+            "Hello =C3=A9 World"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Contains("é", msg.Body);
+    }
+
+
+
+    // ---------- Multipart ----------
+
+    [Fact]
+    public void Parse_when_multipart_mixed_extracts_body_and_attachment()
+    {
+        var attachmentContent = Convert.ToBase64String(new byte[] { 1, 2, 3 });
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: to@example.com",
+            "Subject: Multipart Test",
+            "Content-Type: multipart/mixed; boundary=\"BOUNDARY\"",
+            "",
+            "--BOUNDARY",
+            "Content-Type: text/plain",
+            "",
+            "Plain text body",
+            "--BOUNDARY",
+            "Content-Type: application/octet-stream",
+            "Content-Disposition: attachment; filename=\"data.bin\"",
+            "Content-Transfer-Encoding: base64",
+            "",
+            attachmentContent,
+            "--BOUNDARY--"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Equal("Plain text body", msg.Body);
+        Assert.Equal(1, msg.Attachments.Count);
+        Assert.Equal("data.bin", msg.Attachments[0].Name);
+    }
+
+
+
+    // ---------- Priority ----------
+
+    [Fact]
+    public void Parse_when_x_priority_1_sets_high_priority()
+    {
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: to@example.com",
+            "X-Priority: 1",
+            "",
+            "Body"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Equal(MailPriority.High, msg.Priority);
+    }
+
+
+
+    // ---------- Custom headers ----------
+
+    [Fact]
+    public void Parse_when_custom_headers_present_preserves_them()
+    {
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: to@example.com",
+            "X-Custom-Header: custom-value",
+            "",
+            "Body"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Equal("custom-value", msg.Headers["X-Custom-Header"]);
+    }
+
+
+
+    // ---------- Round-trip ----------
+
+    [Fact]
+    public void Parse_round_trip_with_ToMimeString_preserves_key_fields()
+    {
+        using var original = new MailMessage("from@example.com", "to@example.com");
+        original.Subject = "Round Trip";
+        original.Body = "Test body";
+
+        var eml = original.ToMimeString();
+        using var parsed = EmlParser.Parse(eml);
+
+        Assert.Equal("from@example.com", parsed.From!.Address);
+        Assert.Contains(parsed.To, a => a.Address == "to@example.com");
+        Assert.Equal("Round Trip", parsed.Subject);
+        Assert.Contains("Test body", parsed.Body);
+    }
+
+
+
+    // ---------- File operations ----------
+
+    [Fact]
+    public void ParseFile_when_valid_file_parses_content()
+    {
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: to@example.com",
+            "Subject: File Test",
+            "",
+            "File body"
+        );
+
+        var filePath = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid():N}.eml");
+
+        try
+        {
+            File.WriteAllText(filePath, eml);
+            using var msg = EmlParser.ParseFile(filePath);
+
+            Assert.Equal("File Test", msg.Subject);
+        }
+        finally
+        {
+            if (File.Exists(filePath)) File.Delete(filePath);
+        }
+    }
+
+
+
+    [Fact]
+    public async Task ParseFileAsync_when_valid_file_parses_content()
+    {
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: to@example.com",
+            "Subject: Async File Test",
+            "",
+            "Async body"
+        );
+
+        var filePath = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid():N}.eml");
+
+        try
+        {
+            File.WriteAllText(filePath, eml);
+            using var msg = await EmlParser.ParseFileAsync(filePath);
+
+            Assert.Equal("Async File Test", msg.Subject);
+        }
+        finally
+        {
+            if (File.Exists(filePath)) File.Delete(filePath);
+        }
+    }
+
+
+
+    // ---------- Helpers ----------
+
+    private static string BuildEml
+    (
+        params string[] lines
+    )
+    {
+        return string.Join("\r\n", lines);
+    }
+}

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/EmlParserTests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/EmlParserTests.cs
@@ -402,6 +402,214 @@ public class EmlParserTests
 
 
 
+    // ---------- Coverage for edge cases ----------
+
+    [Fact]
+    public void Parse_when_body_uses_LF_only_separator_parses_correctly()
+    {
+        var eml = "From: sender@example.com\nTo: to@example.com\nSubject: LF Test\n\nBody content";
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Equal("LF Test", msg.Subject);
+        Assert.Equal("Body content", msg.Body);
+    }
+
+
+
+    [Fact]
+    public void Parse_when_headers_are_folded_across_lines_combines_them()
+    {
+        // Folded header: continuation line starts with space or tab
+        var eml = "From: sender@example.com\r\nTo: to@example.com\r\nSubject: This is\r\n a folded\r\n\tsubject\r\n\r\nBody";
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Contains("folded", msg.Subject);
+    }
+
+
+
+    [Fact]
+    public void Parse_when_x_priority_5_sets_low_priority()
+    {
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: to@example.com",
+            "X-Priority: 5",
+            "",
+            "Body"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Equal(MailPriority.Low, msg.Priority);
+    }
+
+
+
+    [Fact]
+    public void Parse_when_multipart_alternative_has_html_adds_as_alternate_view()
+    {
+        // Multipart/alternative: text/plain followed by text/html -> plain becomes Body, html becomes AlternateView
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: to@example.com",
+            "Subject: Alternative",
+            "Content-Type: multipart/alternative; boundary=\"ALT\"",
+            "",
+            "--ALT",
+            "Content-Type: text/plain",
+            "",
+            "Plain text version",
+            "--ALT",
+            "Content-Type: text/html",
+            "",
+            "<p>HTML version</p>",
+            "--ALT--"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Equal("Plain text version", msg.Body);
+        Assert.False(msg.IsBodyHtml);
+        Assert.Single(msg.AlternateViews);
+    }
+
+
+
+    [Fact]
+    public void Parse_when_nested_multipart_handles_inner_parts()
+    {
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: to@example.com",
+            "Content-Type: multipart/mixed; boundary=\"OUTER\"",
+            "",
+            "--OUTER",
+            "Content-Type: multipart/alternative; boundary=\"INNER\"",
+            "",
+            "--INNER",
+            "Content-Type: text/plain",
+            "",
+            "Inner plain",
+            "--INNER--",
+            "--OUTER--"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Equal("Inner plain", msg.Body);
+    }
+
+
+
+    [Fact]
+    public void Parse_when_base64_body_is_malformed_returns_original_text()
+    {
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: to@example.com",
+            "Content-Type: text/plain",
+            "Content-Transfer-Encoding: base64",
+            "",
+            "this is not valid base64 !!!"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        // Should not throw; body preserved as-is on decode failure
+        Assert.False(string.IsNullOrEmpty(msg.Body));
+    }
+
+
+
+    [Fact]
+    public void Parse_when_malformed_From_is_silently_skipped()
+    {
+        var eml = BuildEml
+        (
+            "From: not a valid email!!!",
+            "To: to@example.com",
+            "Subject: Bad From",
+            "",
+            "Body"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        // From should be null or unset, but parsing should not throw
+        Assert.Equal("Bad From", msg.Subject);
+    }
+
+
+
+    [Fact]
+    public void Parse_when_attachment_has_name_in_content_type_extracts_filename()
+    {
+        var attachmentContent = Convert.ToBase64String(new byte[] { 1, 2, 3 });
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: to@example.com",
+            "Content-Type: multipart/mixed; boundary=\"B\"",
+            "",
+            "--B",
+            "Content-Type: text/plain",
+            "",
+            "Body",
+            "--B",
+            "Content-Type: application/octet-stream; name=\"fromtype.bin\"",
+            "Content-Transfer-Encoding: base64",
+            "",
+            attachmentContent,
+            "--B--"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Single(msg.Attachments);
+        Assert.Equal("fromtype.bin", msg.Attachments[0].Name);
+    }
+
+
+
+    [Fact]
+    public void Parse_when_attachment_has_content_id_preserves_it()
+    {
+        var attachmentContent = Convert.ToBase64String(new byte[] { 1, 2, 3 });
+        var eml = BuildEml
+        (
+            "From: sender@example.com",
+            "To: to@example.com",
+            "Content-Type: multipart/mixed; boundary=\"B\"",
+            "",
+            "--B",
+            "Content-Type: text/plain",
+            "",
+            "Body",
+            "--B",
+            "Content-Type: application/octet-stream",
+            "Content-Disposition: attachment; filename=\"data.bin\"",
+            "Content-Transfer-Encoding: base64",
+            "Content-ID: <my-id-123>",
+            "",
+            attachmentContent,
+            "--B--"
+        );
+
+        using var msg = EmlParser.Parse(eml);
+
+        Assert.Single(msg.Attachments);
+        Assert.Equal("my-id-123", msg.Attachments[0].ContentId);
+    }
+
+
+
     // ---------- Helpers ----------
 
     private static string BuildEml


### PR DESCRIPTION
## Summary
- `EmlParser.Parse(string)` — parse EML content string into MailMessage
- `EmlParser.ParseFile(string)` — parse from file path
- `EmlParser.ParseFileAsync(string)` — async file parsing
- Handles base64, quoted-printable, RFC 2047 encoded subjects, multipart MIME, attachments
- Round-trips with `ToMimeString()`

Closes #21

## Test plan
- [x] 17 tests pass on net10.0 and net462
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)