### PR TITLE
Fix duplicate hashtable key in Setup-GitHubPages.ps1

### DIFF
--- a/scripts/Setup-GitHubPages.ps1
+++ b/scripts/Setup-GitHubPages.ps1
@@ -320,10 +320,11 @@ if ($needsDocFxConfig) {
     }
     
     # Create replacements hashtable
+    # Note: PROJECT_NAME and PACKAGE_NAME placeholders both resolve to the same
+    # value in this repo (Wolfgang.Extensions.Mail), so only one entry is needed.
     $replacements = @{
         'Wolfgang.Extensions.Mail' = $projectName
         '{{PROJECT_DESCRIPTION}}' = $projectDescription
-        'Wolfgang.Extensions.Mail' = $packageName
         'https://github.com/Chris-Wolfgang/System.Mail-Extensions' = $githubRepoUrl
         'https://chris-wolfgang.github.io/System.Mail-Extensions' = $docsUrl
     }


### PR DESCRIPTION
## Summary
Removes a duplicate hashtable key in `scripts/Setup-GitHubPages.ps1`:

```diff
 $replacements = @{
+    # Note: PROJECT_NAME and PACKAGE_NAME placeholders both resolve to the same
+    # value in this repo (Wolfgang.Extensions.Mail), so only one entry is needed.
     'Wolfgang.Extensions.Mail' = $projectName
     '{{PROJECT_DESCRIPTION}}' = $projectDescription
-    'Wolfgang.Extensions.Mail' = $packageName
     'https://github.com/Chris-Wolfgang/System.Mail-Extensions' = $githubRepoUrl
     'https://chris-wolfgang.github.io/System.Mail-Extensions' = $docsUrl
 }
```

## Why
PowerShell hashtables can't contain duplicate keys. The literal string `'Wolfgang.Extensions.Mail'` was used as both keys, mapping to `$projectName` and `$packageName`. Only one of the two replacements actually took effect.

In this repo the project name and the package name happen to be identical, so the duplicate entry was redundant. Replaced with a comment so anyone forking with a different package id knows what to do.

## Test plan
- [ ] PowerShell parses the script without warnings
- [ ] Running `setup.ps1` (which invokes Setup-GitHubPages.ps1) substitutes `Wolfgang.Extensions.Mail` correctly