### PR TITLE
Fix MA0003 / RS0030 in MailMessageExtensions and InlineHtmlBuilder

### DIFF
--- a/src/Wolfgang.Extensions.Mail/InlineHtmlBuilder.cs
+++ b/src/Wolfgang.Extensions.Mail/InlineHtmlBuilder.cs
@@ -218,9 +218,9 @@ public sealed class InlineHtmlBuilder
 
         var view = AlternateView.CreateAlternateViewFromString
         (
-            html,
-            null,
-            MediaTypeNames.Text.Html
+            content: html,
+            contentEncoding: null,
+            mediaType: MediaTypeNames.Text.Html
         );
 
         foreach (var resource in _resources)

--- a/src/Wolfgang.Extensions.Mail/MailMessageExtensions.cs
+++ b/src/Wolfgang.Extensions.Mail/MailMessageExtensions.cs
@@ -48,7 +48,7 @@ public static class MailMessageExtensions
         this MailMessage source
     )
     {
-        return Validate(source, null);
+        return Validate(source, options: null);
     }
 
 
@@ -455,6 +455,7 @@ public static class MailMessageExtensions
 
 #pragma warning disable S3011  // Reflection on non-public members is intentional for MIME serialization
 #pragma warning disable VSTHRD002 // Synchronous wait is intentional — SendAsync with SyncReadWriteAdapter completes synchronously
+#pragma warning disable RS0030  // GetAwaiter().GetResult() is intentional — SyncReadWriteAdapter completes synchronously
     [ExcludeFromCodeCoverage] // Branches depend on runtime version; each TFM only exercises one path
     private static void InvokeMailMessageSend
     (
@@ -517,6 +518,7 @@ public static class MailMessageExtensions
             task.GetAwaiter().GetResult();
         }
     }
+#pragma warning restore RS0030
 #pragma warning restore VSTHRD002
 #pragma warning restore S3011
 
@@ -686,10 +688,10 @@ public static class MailMessageExtensions
         // Try 2-parameter constructor first (net6.0+): MailWriter(Stream, bool)
         var ctor = mailWriterType.GetConstructor
         (
-            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
-            null,
-            new[] { typeof(Stream), typeof(bool) },
-            null
+            bindingAttr: BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+            binder: null,
+            types: new[] { typeof(Stream), typeof(bool) },
+            modifiers: null
         );
 
         if (ctor != null)
@@ -700,10 +702,10 @@ public static class MailMessageExtensions
         // Fall back to 1-parameter constructor (net462): MailWriter(Stream)
         ctor = mailWriterType.GetConstructor
         (
-            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
-            null,
-            new[] { typeof(Stream) },
-            null
+            bindingAttr: BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+            binder: null,
+            types: new[] { typeof(Stream) },
+            modifiers: null
         );
 
         if (ctor != null)

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/MailMessageExtensions_Clone_Tests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/MailMessageExtensions_Clone_Tests.cs
@@ -227,9 +227,9 @@ public class MailMessageExtensions_Clone_Tests
         using var original = new MailMessage("from@example.com", "to@example.com");
         var view = AlternateView.CreateAlternateViewFromString
         (
-            "<h1>Hello</h1>",
-            null,
-            "text/html"
+            content: "<h1>Hello</h1>",
+            contentEncoding: null,
+            mediaType: "text/html"
         );
         var resource = new LinkedResource
         (

--- a/tests/Wolfgang.Extensions.Mail.Tests.Unit/MailMessageExtensions_Validate_Tests.cs
+++ b/tests/Wolfgang.Extensions.Mail.Tests.Unit/MailMessageExtensions_Validate_Tests.cs
@@ -154,9 +154,9 @@ public class MailMessageExtensions_Validate_Tests
         msg.Subject = "Test";
         var view = AlternateView.CreateAlternateViewFromString
         (
-            "<h1>Hello</h1>",
-            null,
-            "text/html"
+            content: "<h1>Hello</h1>",
+            contentEncoding: null,
+            mediaType: "text/html"
         );
         msg.AlternateViews.Add(view);
 


### PR DESCRIPTION
## Summary
- Adds named arguments to 6 call sites flagged by Meziantou MA0003 (parameter naming for readability) — `Validate(source, options: null)`, 4× `GetConstructor` calls, 1× `CreateAlternateViewFromString` call.
- Wraps the intentional `task.GetAwaiter().GetResult()` in `InvokeMailMessageSend` with `#pragma warning disable RS0030`. This call is already inside a `#pragma warning disable VSTHRD002` block for the same reason — the sync wait completes synchronously because we pass `SyncReadWriteAdapter` to the SendAsync method.

## Why now
Under main's current analyzer config these surface as warnings; under [#59](https://github.com/Chris-Wolfgang/System.Mail-Extensions/pull/59)'s synced canonical `.editorconfig` + bumped Meziantou version they become Release errors. Splitting this code fix from #59 keeps that PR pure template-drift; merge this first, then rebase #59 onto main and its CI goes green.

## Test plan
- [x] Release build clean across all 12 TFMs (0 warnings, 0 errors)
- [ ] CI green
- [ ] After merge, #59 rebases onto main and goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)