### PR TITLE
chore: sync canonical /docs reference set

### DIFF
--- a/docs/README-FORMATTING.md
+++ b/docs/README-FORMATTING.md
@@ -1,0 +1,68 @@
+# Code Formatting
+
+This repository uses `dotnet format` to enforce consistent C# code style.
+
+## Prerequisites
+
+The `dotnet format` command is **built into the .NET SDK** starting with .NET 6 and later. Since this project requires .NET 8.0 SDK or later, you already have `dotnet format` available — no separate tool installation is needed.
+
+> **Note:** The standalone `dotnet-format` global tool was deprecated when `dotnet format` was integrated into the .NET 6 SDK in August 2021.
+
+## For Developers
+
+### Before Committing
+
+Run the formatting script with PowerShell Core (`pwsh`) on any supported platform:
+
+```powershell
+.\scripts\format.ps1
+```
+
+Or check without making changes:
+
+```powershell
+.\scripts\format.ps1 -Check
+```
+
+### Manual Formatting
+
+```bash
+dotnet format
+```
+
+### Check Formatting (like CI does)
+
+```bash
+dotnet format --verify-no-changes
+```
+
+## Configuration
+
+Code style rules are defined in `.editorconfig` at the repository root.
+
+## CI/CD
+
+Code formatting is enforced locally via `.editorconfig` and `dotnet format`. Run the formatting script before submitting a PR.
+
+### If CI Fails
+
+1. Run `.\scripts\format.ps1` locally
+2. Review the changes
+3. Commit and push the formatted code
+
+## IDE Integration
+
+Most IDEs automatically read `.editorconfig`:
+
+- **Visual Studio**: Built-in support, formats on save (Tools → Options → Text Editor → C# → Code Style)
+- **VS Code**: Install "EditorConfig for VS Code" extension
+- **JetBrains Rider**: Built-in support
+
+## Formatting Rules
+
+Key style rules:
+- **Indentation**: 4 spaces for C# (with `switch` case contents not additionally indented when inside a block, per `.editorconfig`), 2 for XML/JSON
+- **Braces**: Opening brace on new line
+- **Line endings**: LF (Unix style)
+- **Trailing whitespace**: Removed
+- **Using directives**: System namespaces first, sorted alphabetically

--- a/docs/RELEASE-WORKFLOW-SETUP.md
+++ b/docs/RELEASE-WORKFLOW-SETUP.md
@@ -1,0 +1,221 @@
+# Release Workflow Setup Guide
+
+This guide explains how to configure the repository after merging the updated `release.yaml` workflow.
+
+## Overview
+
+The release workflow triggers when you **publish a GitHub Release** and implements a comprehensive validation and automatic deployment process that:
+- ✅ Tests all target frameworks per test project on Windows
+- ✅ Enforces 90% code coverage threshold
+- ✅ Validates NuGet package integrity with smoke tests
+- ✅ Automatically publishes to NuGet.org after validation passes
+- ✅ Eliminates duplicate build work for faster releases
+
+## Required Post-Merge Configuration
+
+After merging this PR, complete the following setup step:
+
+### Add NuGet API Key Secret
+
+**Location:** Settings → Secrets and variables → Actions → New repository secret
+
+1. Click **"New repository secret"**
+2. **Name:** `NUGET_API_KEY`
+3. **Value:** Your NuGet.org API key
+   - Get your key from [NuGet.org Account → API Keys](https://www.nuget.org/account/apikeys)
+   - Recommended scopes: **Push new packages and package versions**
+   - Set expiration date (recommended: 1 year)
+4. Click **"Add secret"**
+
+**What this does:** Allows the workflow to authenticate with NuGet.org and publish packages. The workflow validates this secret exists before attempting to publish.
+
+### Verify Branch Protection Rules
+
+**Location:** Settings → Branches → main
+
+> **Note:** By default, the template is configured for single developer repositories. The branch protection setup script (`scripts/Setup-BranchRuleset.ps1`) includes interactive prompts that allow you to choose between single-developer or multi-developer settings during execution. Simply run the script and select option [1] for single-developer mode (0 approvals) or option [2] for multi-developer mode (1+ approvals and code owner review required).
+
+Ensure the following settings are enabled:
+
+- ✅ **Require a pull request before merging**
+  - **Single developer repos:** 0 approvals (default)
+  - **Multi-developer repos:** 1+ approvals (recommended)
+- ✅ **Require status checks to pass before merging**
+  - Required checks should include the following status check contexts:
+    - "Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate"
+    - "Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)"
+    - "Stage 3: macOS Tests (.NET 6.0-10.0)"
+    - "Security Scan (DevSkim)"
+    - "Security Scan (CodeQL)"
+- ✅ **Require branches to be up to date before merging**
+- ✅ **Require conversation resolution before merging**
+- ✅ **Do not allow bypassing the above settings** (recommended, even for admins)
+- ✅ **Restrict deletions**
+- ✅ **Require linear history** (optional but recommended)
+
+**What this does:** Ensures all code merged to `main` has passed comprehensive validation, preventing broken releases.
+
+## Testing the Release Workflow
+
+After completing the setup, test the workflow by creating a GitHub Release:
+
+1. Go to your repository's **Releases** page
+2. Click **"Draft a new release"**
+3. Choose or create a tag (e.g., `v0.0.1-test`)
+4. Add a title and description (optional for a test)
+5. Check **"Set as a pre-release"** for test releases
+6. Click **"Publish release"**
+
+The workflow triggers automatically when the release is published.
+
+### Expected Workflow Behavior
+
+1. **Job 1: validate-release** (3-10 minutes)
+   - Runs all framework tests with coverage
+   - Enforces 90% coverage threshold
+   - Uploads coverage report
+   - ✅ Auto-passes if tests succeed
+
+2. **Job 2: pack-and-validate** (2-5 minutes)
+   - Packs NuGet packages
+   - Performs smoke test installation
+   - Uploads packages as artifacts
+   - ✅ Auto-passes if packages are valid
+
+3. **Job 3: publish-nuget** (1-2 minutes)
+   - Validates NUGET_API_KEY secret
+   - Publishes packages to NuGet.org automatically
+   - ✅ Auto-completes if secret is valid
+
+### Monitoring the Workflow
+
+- **Actions Tab:** Shows workflow progress in real-time
+- **Artifacts:** Each job uploads artifacts (coverage reports, packages)
+- **Releases:** Check the Releases page after successful completion
+
+## Troubleshooting
+
+### "NUGET_API_KEY secret not configured" Error
+
+**Problem:** The `publish-nuget` job fails with secret validation error.
+
+**Solution:**
+1. Verify the secret name is exactly `NUGET_API_KEY` (case-sensitive)
+2. Re-add the secret in Settings → Secrets → Actions
+3. Re-run the workflow from the Actions tab (do not re-publish the release)
+
+### Tests Fail on Specific Framework
+
+**Problem:** Tests pass on some frameworks but fail on others (e.g., net462).
+
+**Solution:**
+1. Check the test logs for framework-specific issues
+2. Fix compatibility issues in your code
+3. Test locally: `dotnet test --framework net462`
+4. Push fix, then re-publish the release (or re-run the workflow from the Actions tab)
+
+### Coverage Below 90% Threshold
+
+**Problem:** Workflow fails at coverage validation step.
+
+**Solution:**
+1. Review `CoverageReport/Summary.txt` artifact
+2. Add tests for uncovered code paths
+3. Ensure tests run on all frameworks
+4. Push fix, then re-publish the release (or re-run the workflow from the Actions tab)
+
+### Smoke Test Fails to Install Package
+
+**Problem:** Package packs successfully but fails smoke test installation.
+
+**Solution:**
+1. Check package dependencies in `.csproj`
+2. Verify framework compatibility in `<TargetFrameworks>`
+3. Test locally: `dotnet pack` then try installing in a test project
+4. Fix packaging issues and re-publish the release (or re-run the workflow from the Actions tab)
+
+## Production Release Checklist
+
+Before creating a production GitHub Release (e.g., `v1.0.0`):
+
+- [ ] All tests pass on all platforms (pr.yaml workflow)
+- [ ] Code coverage meets 90% threshold
+- [ ] Security scan shows no critical issues
+- [ ] Version numbers updated in `.csproj` files
+- [ ] `CHANGELOG.md` updated with release notes (if applicable)
+- [ ] All PRs merged to `main` branch
+- [ ] Local build succeeds: `dotnet build --configuration Release`
+- [ ] Local tests pass: `dotnet test --configuration Release`
+
+**Create a production release:**
+1. Go to your repository's **Releases** page
+2. Click **"Draft a new release"**
+3. Choose or create the version tag (e.g., `v1.0.0`) targeting `main`
+4. Add a title and release notes
+5. Click **"Publish release"**
+
+**After workflow completes:**
+- [ ] Verify packages appear on NuGet.org
+- [ ] Test installing package from NuGet.org in a clean project
+- [ ] Announce release (if applicable)
+
+## Workflow Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Trigger: Published GitHub Release                          │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Job 1: validate-release (Windows)                          │
+│  • Restore & Build                                          │
+│  • Test all frameworks (net5.0-10.0, net462-481)           │
+│  • Collect coverage                                         │
+│  • Enforce 90% threshold                                    │
+│  • Upload coverage artifacts                                │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼ (only if tests pass)
+┌─────────────────────────────────────────────────────────────┐
+│  Job 2: pack-and-validate (Windows)                         │
+│  • Restore & Build (fresh)                                  │
+│  • Pack NuGet packages                                      │
+│  • Smoke test installation                                  │
+│  • Upload package artifacts                                 │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼ (only if packing succeeds)
+┌─────────────────────────────────────────────────────────────┐
+│  Job 3: publish-nuget (Windows)                             │
+│  • Download packages                                        │
+│  • Validate NUGET_API_KEY                                   │
+│  • Publish to NuGet.org automatically                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Key Improvements Over Previous Workflow
+
+| Issue | Before | After |
+|-------|--------|-------|
+| **Framework Coverage** | Default framework only | All frameworks (net5.0-10.0, net462-481) |
+| **Code Coverage** | Not enforced | 90% threshold enforced |
+| **Package Validation** | None | Smoke test installation |
+| **Deployment** | Incomplete publish script | Automatic publishing after validation |
+| **Secret Validation** | None | Validates before publishing |
+| **GitHub Releases** | Not used as trigger | Workflow triggered by published release |
+| **Build Efficiency** | Duplicate builds in each job | Build once per job with dependencies |
+| **Test Logging** | No logger parameter | Console logging with verbosity |
+| **Permissions** | Read-only | Write access for releases |
+
+## Support
+
+If you encounter issues not covered in this guide:
+
+1. Check the [Actions tab](../../actions) for detailed logs
+2. Review artifacts uploaded by failed jobs
+3. Consult the [GitHub Actions documentation](https://docs.github.com/en/actions)
+4. Open an issue in this repository with:
+   - Workflow run URL
+   - Error message and logs
+   - Steps to reproduce

--- a/docs/WORKFLOW_SECURITY.md
+++ b/docs/WORKFLOW_SECURITY.md
@@ -1,0 +1,177 @@
+# Workflow Security
+
+## Overview
+
+This document describes the security measures implemented in the GitHub Actions workflows for this repository, particularly focusing on the PR validation workflow (`.github/workflows/pr.yaml`).
+
+## Security Architecture
+
+### 1. Workflow YAML Protection
+
+**Mechanism**: `pull_request_target` trigger
+
+The PR workflow uses `pull_request_target` instead of `pull_request`. This means:
+- The workflow YAML file is always executed from the base branch (main)
+- Pull requests cannot modify the workflow logic that validates them
+- Prevents malicious PRs from weakening or bypassing validation checks
+
+**Code Reference**:
+```yaml
+on:
+  pull_request_target:  # Runs from the main branch, not from PR branch
+    branches:
+      - main
+```
+
+### 2. Configuration File Protection
+
+**Problem**: While `pull_request_target` protects the workflow YAML, the checked-out code includes configuration files (`.editorconfig`, `BannedSymbols.txt`, etc.) that control:
+- Code analyzer behavior
+- Code quality standards
+- Security scanning rules
+
+A malicious PR could modify these files to disable security checks.
+
+**Solution**: After checking out the PR code, we fetch and overwrite configuration files from the trusted main branch.
+
+**Protected Configuration Files**:
+- `.editorconfig` - Code style and analyzer rules
+- `Directory.Build.props` - MSBuild properties
+- `Directory.Build.targets` - MSBuild targets
+- `BannedSymbols.txt` - Banned API usage rules
+- `*.globalconfig` - Global analyzer configuration
+- `*.ruleset` - Code analysis rulesets
+
+**Implementation** (added to all workflow jobs):
+```yaml
+- name: Fetch trusted configuration files from main branch
+  run: |
+    echo "Fetching configuration files from main branch to prevent malicious overrides..."
+    
+    # Fetch the main branch
+    git fetch origin main:main-branch
+    
+    # List of configuration files that should come from trusted main branch
+    config_files=(
+      ".editorconfig"
+      "Directory.Build.props"
+      "Directory.Build.targets"
+      "BannedSymbols.txt"
+      "*.globalconfig"
+      "*.ruleset"
+    )
+    
+    # Copy each configuration file from main branch if it exists
+    for config_file in "${config_files[@]}"; do
+      # [Copy logic - see workflow file for full implementation]
+    done
+```
+
+### 3. Credential Protection
+
+**Mechanism**: `persist-credentials: false`
+
+All checkout steps include `persist-credentials: false` to prevent the checkout token from being written to git config:
+
+```yaml
+- name: Checkout code
+  uses: actions/checkout@v4
+  with:
+    ref: refs/pull/${{ github.event.pull_request.number }}/head
+    persist-credentials: false
+```
+
+**Note**: This prevents the token from being stored in git config, but does NOT prevent steps from accessing `GITHUB_TOKEN` if explicitly exposed.
+
+### 4. Minimal Permissions
+
+The workflow runs with minimal required permissions:
+
+```yaml
+permissions:
+  contents: read
+```
+
+This limits the impact if the `GITHUB_TOKEN` is somehow exposed or misused.
+
+## Attack Scenarios Prevented
+
+### Scenario 1: Malicious Workflow Modification
+**Attack**: PR modifies `.github/workflows/pr.yaml` to disable security checks
+**Prevention**: `pull_request_target` ensures workflow runs from main branch
+**Status**: ✅ Protected
+
+### Scenario 2: Configuration File Tampering
+**Attack**: PR modifies `.editorconfig` to disable security analyzers
+**Prevention**: Configuration files are fetched from main branch after checkout
+**Status**: ✅ Protected (as of this PR)
+
+### Scenario 3: Credential Theft
+**Attack**: PR contains malicious code that tries to access GitHub credentials
+**Prevention**: `persist-credentials: false` + minimal permissions
+**Status**: ✅ Protected
+
+### Scenario 4: Code Analysis Bypass
+**Attack**: PR modifies `BannedSymbols.txt` or `.ruleset` to allow dangerous APIs
+**Prevention**: These files are fetched from main branch after checkout
+**Status**: ✅ Protected (as of this PR)
+
+## Validation
+
+The following manual validation scenarios can be used when reviewing changes to the workflow security model:
+
+1. **Configuration Fetch Validation**: Confirm that configuration files are fetched from the `main` branch during workflow execution
+2. **Malicious Modification Validation**: Simulate a PR that modifies `.editorconfig` to disable analyzers and confirm the workflow replaces it with the trusted version from `main`
+
+## Maintenance
+
+### Making Changes to Protected Configuration Files
+
+To update protected configuration files (`.editorconfig`, `BannedSymbols.txt`, etc.), follow this workflow:
+
+1. **Create a PR with your configuration changes**
+   - Make changes to the configuration file(s) in your PR branch
+   - The PR workflow will still fetch and use the current main branch version for testing
+   - This means your PR will be tested against the **existing** configuration standards
+
+2. **Get your PR reviewed and merged to main**
+   - Once merged, your configuration changes become the new "trusted" version on main
+   - Future PRs will automatically use your updated configuration
+
+3. **Why this works:**
+   - Configuration changes are intentionally one commit behind during PR validation
+   - This ensures you can't weaken security standards in the same PR that adds problematic code
+   - After merge, the new standards apply to all subsequent PRs
+
+**Example Workflow:**
+```
+PR #1: Update .editorconfig to add new rule
+  ↓ (tested with old .editorconfig from main)
+  ↓ (approved and merged)
+  ↓
+Main: Now has updated .editorconfig
+
+PR #2: New feature
+  ↓ (tested with updated .editorconfig from main)
+  ↓ (builds/tests using new rules)
+```
+
+**Important Notes:**
+- If you need to relax a security rule AND add code that violates the old rule in the same change, you'll need two PRs:
+  1. First PR: Update the configuration file only
+  2. Second PR: Add the code that requires the relaxed rules
+- This is intentional security design to prevent simultaneous weakening of standards and addition of problematic code
+
+### Adding New Protected Configuration Files
+
+When adding new configuration files that control code quality or security:
+
+1. Add the file name to the `config_files` array in all workflow jobs (detect-projects, test-linux-core, test-windows, test-macos-core, security-scan)
+2. Test that the file is correctly fetched from main branch
+3. Update this documentation
+
+## References
+
+- [GitHub Actions Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
+- [Keeping your GitHub Actions secure](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
+- [Understanding pull_request_target](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)


### PR DESCRIPTION
## Summary
Adds the canonical /docs reference set from repo-template that was missing here:

- `docs/README-FORMATTING.md`
- `docs/RELEASE-WORKFLOW-SETUP.md`
- `docs/WORKFLOW_SECURITY.md`

These are template-level reference docs (release-workflow setup, README formatting conventions, workflow security notes) — kept in sync across all .NET library repos.

## Why
Periodic /docs drift sweep against repo-template main. Files copied verbatim from canonical.